### PR TITLE
Make main menu optional.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,12 +3,14 @@
     <a class="navigation-title" href="{{ "/" | absURL }}">
       {{ .Site.Title }}
     </a>
+    {{with .Site.Menus.main}}
     <ul class="navigation-list float-right">
-      {{ range sort .Site.Menus.main }}
+      {{ range sort . }}
       <li class="navigation-item">
         <a class="navigation-link" href="{{ .URL }}">{{ .Name }}</a>
       </li>
       {{ end }}
     </ul>
+    {{end}}
   </section>
 </nav>


### PR DESCRIPTION
Building the site fails if the menu is not defined in the config,
because the `header.html` references `.Site.Menus.main`. It can be made
optional by using the `with` helper.