### PR TITLE
Update style.less

### DIFF
--- a/static/less/style.less
+++ b/static/less/style.less
@@ -16,7 +16,7 @@ html {
 }
 
 body {
-  display:flex
+  display:flex;
   color: @fg-color;
   background-color: @bg-color;
 	font-family: 'Fira Mono', monospace;

--- a/static/less/style.less
+++ b/static/less/style.less
@@ -16,6 +16,7 @@ html {
 }
 
 body {
+  display:flex
   color: @fg-color;
   background-color: @bg-color;
 	font-family: 'Fira Mono', monospace;


### PR DESCRIPTION
In chrome and safari the main-page content is not shown in the center of the page.
Adding a

display:flex

to the body-styles in the css-file fixes this problem.