### PR TITLE
Update footer to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ theme = "coder" # set the theme
     info = "Full Stack DevOps and Magician" # author's job title or info
     description = "John Doe's personal website" # site description
     keywords = "blog,developer,personal" # site keywords
+
+    # wether you want to hide copyright and credits in the footer
+    hideCredits = false
+    hideCopyright = false
     
 # Social links
 [[params.social]]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,9 @@ disqusShortname = "yourdiscussshortname"
     keywords = "blog,developer,personal"
     info = "Full Stack DevOps and Magician"
 
+    hideCredits = false
+    hideCopyright = false
+
 [[params.social]]
     name = "Github"
     weight = 1

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer">
   <section class="container">
-    © {{ .Site.LastChange.Format "2006" }} · Powered by <a href="https://gohugo.io/">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/">Coder</a>.
+    {{ if not .Site.Params.hideCopyright }} © {{ .Site.LastChange.Format "2006" }} {{ end }} {{ if not .Site.Params.hideCredits}} {{ if not .Site.Params.hideCopyright }} · {{ end }} Powered by <a href="https://gohugo.io/">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/">Coder</a>. {{ end }}
   </section>
 </footer>


### PR DESCRIPTION
As discussed in #6.
Adds the ability to hide (not enabled by default) the copyright notice and/or credits. Configuration was added to README and example site.