### PR TITLE
Generate correct date within archetypes

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,6 @@
 +++ 
 draft = true
+date = {{ .Date }}
 title = ""
 slug = "" 
 +++

--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,6 +1,6 @@
 +++ 
 draft = true
-date = "2018-01-01T00:00:00-00:00"
+date = {{ .Date }}
 title = ""
 slug = "" 
 tags = []


### PR DESCRIPTION
With this fix, after executing `hugo new foo/bar.md`, correct `Date` (essentially `NOW`).will be generated inside content file.