### PR TITLE
Add: support social icons

### DIFF
--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -5,7 +5,7 @@
     {{ with .Site.Params.social }}
     <ul>
       {{ range sort .}}
-      <li><a href="{{ .url }}">{{ .name }}</a></li>
+      <li><a href="{{ .url }}"><i class="fab {{ .icon }}">&nbsp;{{ .name }}</i></a></li>
       {{ end }}
     </ul>
     {{ end }}


### PR DESCRIPTION
With this PR we could use icons for ```params.social```.

Before : 

```toml
[[params.social]]
    name = "Github"
    weight = 1
    url = "https://github.com/nlamirault/"
[[params.social]]
    name = " Gitlab"
    weight = 2
    url = "https://gitlab.com/nicolas-lamirault"
```

After : 

```toml
[[params.social]]
    name = ""
    icon = "fa-github"
    weight = 1
    url = "https://github.com/nlamirault/"
[[params.social]]
    name = " "
    icon = "fa-gitlab"
    weight = 2
    url = "https://gitlab.com/nicolas-lamirault"
```
![2018-06-11-113600_1257x881_scrot](https://user-images.githubusercontent.com/29233/41224053-c0cd1de6-6d6b-11e8-8daa-1a9e20a0dd65.png)
![2018-06-11-113503_1232x875_scrot](https://user-images.githubusercontent.com/29233/41224054-c0ef0eec-6d6b-11e8-82aa-478875682241.png)

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>