### PR TITLE
Fixed reference to old _colors variable name

### DIFF
--- a/assets/scss/coder-rtl.scss
+++ b/assets/scss/coder-rtl.scss
@@ -1,4 +1,4 @@
-@import "_colors";
+@import "_variables";
 @import "_base_rtl";
 @import "_content_rtl";
 @import "_navigation_rtl";


### PR DESCRIPTION
Using RTL would fail due to _colors no longer being available. Changed to import _variables instead.