### PR TITLE
Paginate By Date

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@
 - [Vinícius dos Santos Oliveira](https://github.com/vinipsmaker)
 - [Vlad Ionescu](https://github.com/Vlaaaaaaad)
 - [Joseph Ting](https://github.com/josephting)
+- [Mish Ochu](https://github.com/mishfit)

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -6,7 +6,7 @@
     <h1 class="title">{{ .Title }}</h1>
 
     <ul>
-      {{- range .Paginator.Pages -}}
+      {{- range (.Paginate ( .Pages.ByDate)).Pages -}}
         {{- .Render "li" -}}
       {{- end -}}
     </ul>


### PR DESCRIPTION
# Pull Request Checklist
- Paginate by date by default
  - Ordinary page listings order by weight, date, link title, then file path. Pagination orders by date modified. I've added front matter date back in as a default order
- If left as is, post dates can be jumbled if modified date and "published" (front matter) date don't match. I've initialized a Paginator with options passed in to `.Paginate`
- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable
- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files.
- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
