### PR TITLE
Accept boolean as well as string

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@
 - [Vlad Ionescu](https://github.com/Vlaaaaaaad)
 - [Joseph Ting](https://github.com/josephting)
 - [Abner Campanha](https://github.com/abnerpc)
+- [Martin Kiesel](https://github.com/Kyslik)

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -1,4 +1,4 @@
-{{- if eq .Params.math "true" -}}
+{{- if (or (eq .Params.math true) (eq .Params.math "true")) -}}
   <script type="text/javascript" async
     src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full">
     MathJax.Hub.Config({

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -1,4 +1,4 @@
-{{- if (or (eq .Params.math true) (eq .Params.math "true")) -}}
+{{- if .Params.math -}}
   <script type="text/javascript" async
     src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full">
     MathJax.Hub.Config({


### PR DESCRIPTION
Some flags / switches accept only boolean value of `true` (`pygmentscodefences`), but `math` flag currently accepts only string `"true"`.

This change introduces no breaking change, math can be both `true` and `"true"`. When V2 hits it can be changed to accept only `true`.