### PR TITLE
Remove base url

### DIFF
--- a/exampleSite/content/posts/migrate-from-jekyll.md
+++ b/exampleSite/content/posts/migrate-from-jekyll.md
@@ -3,6 +3,21 @@ date = "2014-03-10"
 title = "Migrate to Hugo from Jekyll"
 +++
 
+Table of Contents
+=================
+
+1. [Move static content to `static`](#move-static-content-to-static)
+2. [Create your Hugo configuration file](#create-your-hugo-configuration-file)
+3. [Set your configuration publish folder to `site`](#set-your-configuration-publish-folder-to-site)
+4. [Convert Jekyll templates to Hugo templates](#convert-jekyll-templates-to-hugo-templates)
+5. [Convert Jekyll plugins to Hugo shortcodes](#convert-jekyll-plugins-to-hugo-shortcodes)
+    * [Implementation](#implementation)
+    * [Usage](#usage)
+6. [Finishing Touches](#finishing-touches)
+    * [Fix Content](#fix-content)
+    * [Clean Up](#clean-up)
+7. [A practical example in a diff](#a-practical-example-in-a-diff)
+
 ## Move static content to `static`
 Jekyll has a rule that any directory not starting with `_` will be copied as-is to the `_site` output. Hugo keeps all static content under `static`. You should therefore move it all there.
 With Jekyll, something that looked like

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,6 @@
     {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
     {{ with .Site.Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
 
-    <base href="{{ .Site.BaseURL }}">
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
 
     <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Base URL tag is causing table of contents links to not work properly.

Expected: Move browser view to anchor
Current: Goes back to home page

Tested with deploy previews and made sure that existing links work.

Added table of contents to one of the post in exampleSite for simple demo.

### Issues Resolved

Fixes #128 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
