### PR TITLE
Fix pagination style

### DIFF
--- a/assets/scss/_pagination.scss
+++ b/assets/scss/_pagination.scss
@@ -1,15 +1,18 @@
 .pagination {
   margin-top: 6.0rem;
   text-align: center;
+  font-family: $heading-font-family;
   li {
     display: inline;
     text-align: center;
+    font-weight: 700;
     span {
       margin: 0;
       text-align: center;
       width: 3.2rem;
     }
     a {
+      font-weight: 300;
       span {
         margin: 0;
         text-align: center;


### PR DESCRIPTION
This fixes the weird styling for the pagination links.

Now it looks like this:

![screenshot from 2019-02-10 20-46-48](https://user-images.githubusercontent.com/1427376/52540891-f4067c00-2d75-11e9-90b9-30c9e9082bf7.png)

Fixes #143.
