### PR TITLE
Add OpenGraph Protocol Support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@
 - [Artem Khvastunov](https://artspb.me)
 - [Gabriel Nepomuceno] (https://blog.nepomuceno.me)
 - [Salvatore Giordano] (https://salvatore-giordano.github.io)
+- [Jeffrey Carpenter](https://uvolabs.me)

--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -7,4 +7,5 @@ slug = ""
 tags = []
 categories = []
 externalLink = ""
+series = []
 +++

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -39,6 +39,9 @@ disqusShortname = "yourdiscussshortname"
     # Custom CSS
     custom_css = []
 
+[taxonomies]
+  series = "series"
+
 [[params.social]]
     name = "Github"
     icon = "fab fa-github"

--- a/exampleSite/content/posts/goisforlovers.md
+++ b/exampleSite/content/posts/goisforlovers.md
@@ -13,6 +13,7 @@ categories = [
     "Development",
     "golang",
 ]
+series = ["Getting Started"]
 +++
 
 Hugo uses the excellent [go][] [html/template][gohtmltemplate] library for

--- a/exampleSite/content/posts/hugoisforlovers.md
+++ b/exampleSite/content/posts/hugoisforlovers.md
@@ -11,6 +11,7 @@ categories = [
     "Development",
     "golang",
 ]
+series = ["Getting Started"]
 +++
 
 ## Step 1. Install Hugo

--- a/exampleSite/content/posts/migrate-from-jekyll.md
+++ b/exampleSite/content/posts/migrate-from-jekyll.md
@@ -2,6 +2,7 @@
 date = "2014-03-10"
 title = "Migrate to Hugo from Jekyll"
 description = "The post explains how to migrate from from Jekyll to Hugo."
+series = ["Getting Started"]
 +++
 
 Table of Contents

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,6 +10,7 @@
     {{ with .Site.Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
 
     {{ template "_internal/twitter_cards.html" . }}
+    {{ template "_internal/opengraph.html" . }}
 
     <base href="{{ .Permalink }}">
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
### Prerequisites

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Add OpenGraph Protocol support. OpenGraph Protocol is used by sites like Facebook to display a rich object in a social graph.

### General

* Add OpenGraph Protocol to each page

Hugo has an internal template for [Open Graph](https://gohugo.io/templates/internal/#open-graph). It takes necessary information from either site's or post's config thus it makes sense to add it to each page.

* Add 'series' to posts archetype
This taxonomy is used to specify related “see also” pages by placing them in the same series.

* Add series taxonomy to exampleSite config.

* Add example of series to exampleSite

### Contributors

* Add spaz926 to Contributors
