### PR TITLE
Fix HTML syntax for aria-hidden attribute

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@
 - [Gabriel Nepomuceno] (https://blog.nepomuceno.me)
 - [Salvatore Giordano] (https://salvatore-giordano.github.io)
 - [Jeffrey Carpenter](https://uvolabs.me)
+- [Paul Lettington](https://github.com/plett)

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -11,7 +11,7 @@
         {{ if .icon }}
           <li>
             <a href="{{ .url }}" aria-label="{{ .name }}">
-              <i class="{{ .icon }}" aria-hidden></i>
+              <i class="{{ .icon }}" aria-hidden="true"></i>
             </a>
           </li>
         {{ else }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This PR adds the value `"true"` to the `aria-hidden` attribute on social media icons. aria-hidden attributes without values are not valid HTML syntax and cause errors when running the page through a HTML validator.

I have verified that there is no difference in spoken output from ChromeVox on a Chromebook with the change.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
