### PR TITLE
Fix external link on pages list

### DIFF
--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -11,7 +11,7 @@
     {{ range .Paginator.Pages }}
     <li>
       <span class="date">{{ .Date.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</span>
-      <a class="title" href="{{ .URL }}">{{ .Title }}</a>
+      <a class="title" href="{{ .Params.ExternalLink | default .URL }}">{{ .Title }}</a>
     </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Currently, external link on categories/tags/series list page do not link to specified external link.
This PR fixes that.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
