### PR TITLE
Add KaTeX support

### DIFF
--- a/exampleSite/content/posts/render-latex-using-katex.md
+++ b/exampleSite/content/posts/render-latex-using-katex.md
@@ -1,0 +1,36 @@
++++
+date = "2019-03-20"
+title = "Render LaTeX using KaTeX"
+description = "Katex support demo"
+katex = "true"
+series = ["Theme", "Hugo"]
++++
+
+Enable katex by adding `katex = "true"` to the [front matter](https://gohugo.io/content-management/front-matter/)  
+
+```toml
++++
+katex = "true"
++++
+```
+
+It's almost a dropin alternative to the mathjax solution,you should just choose one of them.  
+
+Inline math looks like this  
+
+```tex
+This is text with inline math $\sum_{n=1}^{\infty} 2^{-n} = 1$
+```
+
+This is text with inline math $\sum_{n=1}^{\infty} 2^{-n} = 1$  
+and with math blocks:  
+
+```tex
+$$
+\sum_{n=1}^{\infty} 2^{-n} = 1
+$$
+```
+
+$$
+\sum_{n=1}^{\infty} 2^{-n} = 1
+$$

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -22,3 +22,17 @@
     });
   </script>
 {{- end -}}
+{{- if .Params.katex -}}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.js" integrity="sha384-2BKqo+exmr9su6dir+qCw08N2ZKRucY4PrGQPPWU1A7FtlCGjmEGFqXCv5nyM5Ij" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"
+    onload="renderMathInElement(document.body,
+      {
+        delimiters: [
+          {left: '$$', right: '$$', display:true},
+          {left: '$', right: '$', display:false},
+        ]
+      }
+    );">
+  </script>
+{{- end -}}


### PR DESCRIPTION
* Add render-latex-using-katex.md to Demonstarate how to use the katex

* Update math.html add katex scripts and css

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

* Add render-latex-using-katex.md to demonstarate how to use the katex

* Update math.html add katex scripts and css

implement katex support
It has been tested by me and it works
this won't break anything
users can choose either mathjax or katex from the post page front matter

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
