### PR TITLE
use safeHTML in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
   <section class="container">
-    {{ with .Site.Params.footercontent }}
+    {{ with .Site.Params.footercontent | safeHTML }}
       <p>{{.}}</p>
     {{ end }}
     {{ if not .Site.Params.hideCopyright }} © {{ now.Format "2006" }}{{ end }}


### PR DESCRIPTION
While building website with your AWESOME theme I stubled upon a small problem.
When I tried to put link in footer i got this:
![image](https://user-images.githubusercontent.com/3140296/57574810-36585b80-7440-11e9-8516-a3c882d56e17.png)

My small change allows user to do this:
![image](https://user-images.githubusercontent.com/3140296/57574823-4f610c80-7440-11e9-827a-65049a970c85.png)

I hope this modification matches your overall architecture of the theme :) 