### PR TITLE
Add custom_js site param for enabling custom js

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@
 - [D_DAndrew](https://d-dandrew.github.io)
 - [Wataru Mizukami](https://github.com/tarumzu)
 - [Yudi Widiyanto](https://github.com/yudiwdynto)
+- [Łukasz Mróz](https://github.com/mrozlukasz)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -41,6 +41,9 @@ disqusShortname = "yourdiscussshortname"
 
     # Custom CSS
     custom_css = []
+    
+    # Custom JS
+    custom_js = []
 
 [taxonomies]
   category = "categories"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -60,7 +60,7 @@
     {{ end }}
 
     {{ range .Site.Params.custom_css }}
-      <link rel="stylesheet" href="{{ . | relURL }}"/>
+      <link rel="stylesheet" href="{{ . | relURL }}" />
     {{ end }}
 
     {{ range .Site.Params.custom_js }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -60,9 +60,13 @@
     {{ end }}
 
     {{ range .Site.Params.custom_css }}
-      <link rel="stylesheet" href="{{ . | relURL }}">
+      <link rel="stylesheet" href="{{ . | relURL }}"/>
     {{ end }}
 
+    {{ range .Site.Params.custom_js }}
+      <script src="{{ . | relURL }}"></script>
+    {{ end }}
+    
     <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_32 | default "/images/favicon-32x32.png" | absURL }}" sizes="32x32">
     <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_16 | default "/images/favicon-16x16.png" | absURL }}" sizes="16x16">
 


### PR DESCRIPTION
I've hit that when adding Cookie Consent on my web page. https://github.com/insites/cookieconsent

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Allows to add custom javascript source files in html head page. I need this for features like Cookie Consent. 

### Issues Resolved

Haven't seen any related

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
