### PR TITLE
Add .html to partials

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,4 @@
 - [Wataru Mizukami](https://github.com/tarumzu)
 - [Yudi Widiyanto](https://github.com/yudiwdynto)
 - [Łukasz Mróz](https://github.com/mrozlukasz)
+- [Jia "Jay" Tan](https://github.com/j7an)

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -21,8 +21,8 @@
               {{ i18n "reading_time" .ReadingTime }}
             </span>
           </div>
-          {{ with .Page.Params.Categories }}{{ partial "taxonomy/categories" . }}{{ end }}
-          {{ with .Page.Params.Tags }}{{ partial "taxonomy/tags" . }}{{ end }}
+          {{ with .Page.Params.Categories }}{{ partial "taxonomy/categories.html" . }}{{ end }}
+          {{ with .Page.Params.Tags }}{{ partial "taxonomy/tags.html" . }}{{ end }}
         </div>
       </header>
 
@@ -31,11 +31,11 @@
       </div>
 
       <footer>
-        {{ partial "posts/series" . }}
-        {{ partial "posts/disqus" . }}
+        {{ partial "posts/series.html" . }}
+        {{ partial "posts/disqus.html" . }}
       </footer>
     </article>
 
-    {{ partial "posts/math" . }}
+    {{ partial "posts/math.html" . }}
   </section>
 {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Add `.html` to partials in posts/single.html template.

### Issues Resolved

Partials not being added to generated blog posts.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
 - Correct syntax requires `.html` in partial filename as stated on Hugo documentation.
- [x] Reference issue with `#<ISSUE_NO>` if applicable
 - #187

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
