### PR TITLE
Check if commentoUrl is set before using it.

### DIFF
--- a/layouts/partials/posts/commento.html
+++ b/layouts/partials/posts/commento.html
@@ -1,4 +1,4 @@
-{{- if and (not (eq .Site.Params.commentoUrl "" )) (eq (.Params.disable_comments | default false) false) -}}
+{{- if and (isset .Site.Params "commentourl") (not (eq .Site.Params.commentoUrl "" )) (eq (.Params.disable_comments | default false) false) -}}
 <div id="commento"></div>
 <script src="{{ .Site.Params.commentoUrl }}/js/commento.js"></script>
 {{- end -}}

--- a/layouts/partials/posts/disqus.html
+++ b/layouts/partials/posts/disqus.html
@@ -1,3 +1,3 @@
-{{- if and (not (eq .Site.DisqusShortname "" )) (eq (.Params.disable_comments | default false) false) -}}
+{{- if and (isset .Site "disqusshortname") (not (eq .Site.DisqusShortname "" )) (eq (.Params.disable_comments | default false) false) -}}
   {{ template "_internal/disqus.html" . }}
 {{- end -}}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [X] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Prevents including HTML that will not work and that refers to a non-existent file.

### Issues Resolved

None.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [X] Describe what changes are being made
- [X] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

When a variable does not exist it evaluates to `nil`, and so the check `(not (eq .Site.Params.commentoUrl ""))` evaluates to true rather than false because `nil` is not "".  Before this change, unless you explicitly set `Params.commentoUrl` to `""`, the commento HTML block would be added, and this does not work in the browser because `/js/commento.js` does not exist.  This change ensures that the commento HTML block is only added when Params.commentoUrl exists and is set to a non-empty string.



#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
