### PR TITLE
disqus: fixed issue #199

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@
 - [Łukasz Mróz](https://github.com/mrozlukasz)
 - [Jia "Jay" Tan](https://github.com/j7an)
 - [Ryan](https://github.com/alrayyes)
+- [Naim A.](https://github.com/naim94a)

--- a/layouts/partials/posts/disqus.html
+++ b/layouts/partials/posts/disqus.html
@@ -1,3 +1,3 @@
-{{- if and (isset .Site "disqusshortname") (not (eq .Site.DisqusShortname "" )) (eq (.Params.disable_comments | default false) false) -}}
+{{- if and (not (eq (.Site.DisqusShortname | default "") "")) (eq (.Params.disable_comments | default false) false) -}}
   {{ template "_internal/disqus.html" . }}
 {{- end -}}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This prevents Hugo from printing a warning and never rendering Disqus comments.

This PR changes the way the template determines if disqus should be rendered.

### Issues Resolved

- Resolves Issue #199 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
