### PR TITLE
corrected multi language links

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,3 +41,4 @@
 - [Jia "Jay" Tan](https://github.com/j7an)
 - [Ryan](https://github.com/alrayyes)
 - [Naim A.](https://github.com/naim94a)
+- [Alexander Rohde](https://github.com/a1x42)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -84,22 +84,22 @@ disqusShortname = "yourdiscussshortname"
         [[languages.en.menu.main]]
         name = "About"
         weight = 1
-        url = "/about/"
+        url = "about/"
 
         [[languages.en.menu.main]]
         name = "Blog"
         weight = 2
-        url = "/posts/"
+        url = "posts/"
 
         [[languages.en.menu.main]]
         name = "Projects"
         weight = 3
-        url = "/projects/"
+        url = "projects/"
 
         [[languages.en.menu.main]]
         name = "Contact me"
         weight = 5
-        url = "/contact/"
+        url = "contact/"
 
 
     [languages.pt-br]
@@ -118,19 +118,19 @@ disqusShortname = "yourdiscussshortname"
             [[languages.pt-br.menu.main]]
             name = "Sobre"
             weight = 1
-            url = "/pt-br/about/"
+            url = "about/"
 
             [[languages.pt-br.menu.main]]
             name = "Blog"
             weight = 2
-            url = "/pt-br/posts/"
+            url = "posts/"
 
             [[languages.pt-br.menu.main]]
             name = "Projetos"
             weight = 3
-            url = "/pt-br/projects/"
+            url = "projects/"
 
             [[languages.pt-br.menu.main]]
             name = "Contato"
             weight = 5
-            url = "/pt-br/contact/"
+            url = "contact/"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <nav class="navigation">
   <section class="container">
-    <a class="navigation-title" href="{{ .Site.BaseURL | absLangURL }}">
+    <a class="navigation-title" href="{{ .Site.BaseURL | relLangURL }}">
       {{ .Site.Title }}
     </a>
     <input type="checkbox" id="menu-toggle" />
@@ -9,7 +9,7 @@
       {{ with .Site.Menus.main}}
         {{ range sort . }}
           <li class="navigation-item">
-            <a class="navigation-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
+            <a class="navigation-link" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
           </li>
         {{ end }}
       {{ end }}


### PR DESCRIPTION


### Prerequisites

Put an `x` into the box(es) that apply:

- [x ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

correction of header partial to render the correct multi language URLs for main page and menu items including language prefix.

### Issues Resolved

Before, the URL to sites in languages different to the default language needed the language prefix.
When in a non-default language the main link (i.e. click on title) always returned to the default language

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already