### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ This theme is maintained by its author [Luiz de Prá](https://github.com/luizdep
 
 - Gleen McComb, for his great [article](https://glennmccomb.com/articles/how-to-build-custom-hugo-pagination/) about custom pagination.
 - All contributors, for every PR and Issue reported.
+
+## Stackbit
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/luizdepra/hugo-coder)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -81,25 +81,27 @@ disqusShortname = "yourdiscussshortname"
     [languages.en]
         languagename = "English"
 
-        [[languages.en.menu.main]]
-        name = "About"
-        weight = 1
-        url = "about/"
+        [languages.en.menu]
 
-        [[languages.en.menu.main]]
-        name = "Blog"
-        weight = 2
-        url = "posts/"
+            [[languages.en.menu.main]]
+            name = "About"
+            weight = 1
+            url = "about/"
 
-        [[languages.en.menu.main]]
-        name = "Projects"
-        weight = 3
-        url = "projects/"
+            [[languages.en.menu.main]]
+            name = "Blog"
+            weight = 2
+            url = "posts/"
 
-        [[languages.en.menu.main]]
-        name = "Contact me"
-        weight = 5
-        url = "contact/"
+            [[languages.en.menu.main]]
+            name = "Projects"
+            weight = 3
+            url = "projects/"
+
+            [[languages.en.menu.main]]
+            name = "Contact me"
+            weight = 5
+            url = "contact/"
 
 
     [languages.pt-br]

--- a/exampleSite/content/posts/render-latex-using-katex.md
+++ b/exampleSite/content/posts/render-latex-using-katex.md
@@ -2,7 +2,7 @@
 date = "2019-03-20"
 title = "Render LaTeX using KaTeX"
 description = "Katex support demo"
-katex = "true"
+katex = true
 series = ["Theme", "Hugo"]
 +++
 

--- a/exampleSite/content/posts/theme-demo.md
+++ b/exampleSite/content/posts/theme-demo.md
@@ -3,7 +3,7 @@ date = "2017-01-08"
 title = "Theme Demo"
 description = "The post demonstrates features of the coder theme."
 images = ["/images/N90.jpg"]
-math = "true"
+math = true
 series = ["Theme", "Hugo"]
 +++
 

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -193,6 +193,7 @@ models:
             name: main
             items:
               type: object
+              labelField: name
               fields:
                 - type: string
                   name: identifier

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,149 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: demo/public
+buildCommand: make prepare && hugo --source demo --baseURL "/"
+uploadDir: images
+staticDir: exampleSite/static
+pagesDir: exampleSite/content
+dataDir: exampleSite
+models:
+  config:
+    type: data
+    label: Config
+    file: config.toml
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+      - type: string
+        name: baseurl
+        label: Base URL
+        description: Hostname (and path) to the root
+      - type: string
+        name: languagecode
+      - type: string
+        name: defaultcontentlanguage
+      - type: string
+        name: themesDir
+      - type: string
+        name: theme
+        label: Theme Name
+      - type: number
+        name: paginate
+      - type: boolean
+        name: canonifyurls
+      - type: string
+        name: pygmentsstyle
+      - type: boolean
+        name: pygmentscodefences
+      - type: boolean
+        name: pygmentscodefencesguesssyntax
+      - type: string
+        name: disqusShortname
+      - type: object
+        name: params
+        label: Params
+        description: Site parameters
+        fields:
+          - type: string
+            name: author
+          - type: string
+            name: description
+          - type: string
+            name: keywords
+          - type: string
+            name: info
+          - type: string
+            name: avatarurl
+          - type: string
+            name: footercontent
+          - type: string
+            name: dateformat
+          - type: boolean
+            name: hideCredits
+          - type: boolean
+            name: hideCopyright
+          - type: string
+            name: commit
+          - type: boolean
+            name: rtl
+          - type: boolean
+            name: inverted
+          - type: number
+            name: maxSeeAlsoItems
+          - type: list
+            name: custom_css
+          - type: list
+            name: custom_js
+          - type: list
+            name: social
+            label: Social Media Icons
+            items: 
+              type: object
+              fields:
+                - type: string
+                  name: name
+                  label: Name
+                - type: string
+                  name: icon
+                  label: Icon
+                - type: number
+                  name: weight
+                  label: Weight
+                - type: string
+                  name: url
+                  label: URL
+      - type: object
+        name: languages
+      - type: object
+        name: taxonomies
+        fields:
+          - type: string
+            name: category
+          - type: string
+            name: series
+          - type: string
+            name: tag
+  basicpage:
+    type: page
+    label: Basic Page
+    match: '*.md'
+    exclude: 
+      - _index.md
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: string
+        name: slug
+        label: Slug
+  post:
+    type: page
+    label: Blog post
+    folder: posts
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: date
+        name: date
+        label: Date
+      - type: slug
+        name: slug
+        label: Slug
+      - type: list
+        name: tags
+        label: Tags
+        items:
+          type: string
+      - type: list
+        name: categories
+        label: Categories
+        items:
+          type: string
+      - type: list
+        name: series
+        label: Series
+        items:
+          type: string

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -129,7 +129,7 @@ models:
       - type: date
         name: date
         label: Date
-      - type: slug
+      - type: string
         name: slug
         label: Slug
       - type: list

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -79,7 +79,7 @@ models:
           - type: list
             name: social
             label: Social Media Icons
-            items: 
+            items:
               type: object
               fields:
                 - type: string
@@ -96,6 +96,11 @@ models:
                   label: URL
       - type: object
         name: languages
+        fields:
+          - type: language_config
+            name: en
+          - type: language_config
+            name: "pt-br"
       - type: object
         name: taxonomies
         fields:
@@ -108,8 +113,8 @@ models:
   basicpage:
     type: page
     label: Basic Page
-    match: '*.md'
-    exclude: 
+    match: "*.md"
+    exclude:
       - _index.md
     fields:
       - type: string
@@ -147,3 +152,75 @@ models:
         label: Series
         items:
           type: string
+      - type: string
+        name: externalLink
+      - type: string
+        name: description
+      - type: boolean
+        name: math
+      - type: boolean
+        name: katex
+      - type: list
+        name: images
+        items:
+          type: string
+  language_config:
+    - type: object
+      fields:
+        - type: string
+          name: languagename
+        - type: string
+          name: title
+        - type: object
+          name: params
+          fields:
+            - type: string
+              name: author
+            - type: string
+              name: info
+            - type: string
+              name: description
+            - type: string
+              name: keywords
+            - type: string
+              name: footercontent
+        - type: site_menus
+          name: menu
+  site_menus:
+    type: object
+    label: Site Menus
+    description: >-
+      Site menus model, defines list of menus that can be specified from within
+      site configuration
+    fields:
+      - type: list
+        name: main
+        label: Main menu
+        description: List of items for Main menu
+        items:
+          type: site_menu_item
+  site_menu_item:
+    type: object
+    label: Site Menu Item
+    labelField: name
+    description: "Site menu item model, defines fields for a single site menu item"
+    fields:
+      - type: string
+        name: identifier
+        label: Identifier
+      - type: string
+        name: name
+        label: Title
+        required: true
+      - type: string
+        name: url
+        label: URL
+        required: true
+      - type: number
+        name: weight
+        label: Weight
+        description: Position for sorting
+      - type: string
+        name: parent
+        label: Parent Menu Identifier
+        description: The parent of an entry should be the identifier of another entry.

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -165,27 +165,28 @@ models:
         items:
           type: string
   language_config:
-    - type: object
-      fields:
-        - type: string
-          name: languagename
-        - type: string
-          name: title
-        - type: object
-          name: params
-          fields:
-            - type: string
-              name: author
-            - type: string
-              name: info
-            - type: string
-              name: description
-            - type: string
-              name: keywords
-            - type: string
-              name: footercontent
-        - type: site_menus
-          name: menu
+    type: object
+    label: Language Config
+    fields:
+      - type: string
+        name: languagename
+      - type: string
+        name: title
+      - type: object
+        name: params
+        fields:
+          - type: string
+            name: author
+          - type: string
+            name: info
+          - type: string
+            name: description
+          - type: string
+            name: keywords
+          - type: string
+            name: footercontent
+      - type: site_menus
+        name: menu
   site_menus:
     type: object
     label: Site Menus

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -185,43 +185,31 @@ models:
             name: keywords
           - type: string
             name: footercontent
-      - type: site_menus
+      - type: object
+        label: Menu
         name: menu
-  site_menus:
-    type: object
-    label: Site Menus
-    description: >-
-      Site menus model, defines list of menus that can be specified from within
-      site configuration
-    fields:
-      - type: list
-        name: main
-        label: Main menu
-        description: List of items for Main menu
-        items:
-          type: site_menu_item
-  site_menu_item:
-    type: object
-    label: Site Menu Item
-    labelField: name
-    description: "Site menu item model, defines fields for a single site menu item"
-    fields:
-      - type: string
-        name: identifier
-        label: Identifier
-      - type: string
-        name: name
-        label: Title
-        required: true
-      - type: string
-        name: url
-        label: URL
-        required: true
-      - type: number
-        name: weight
-        label: Weight
-        description: Position for sorting
-      - type: string
-        name: parent
-        label: Parent Menu Identifier
-        description: The parent of an entry should be the identifier of another entry.
+        fields:
+          - type: list
+            name: main
+            items:
+              type: object
+              fields:
+                - type: string
+                  name: identifier
+                  label: Identifier
+                - type: string
+                  name: name
+                  label: Title
+                  required: true
+                - type: string
+                  name: url
+                  label: URL
+                  required: true
+                - type: number
+                  name: weight
+                  label: Weight
+                  description: Position for sorting
+                - type: string
+                  name: parent
+                  label: Parent Menu Identifier
+                  description: The parent of an entry should be the identifier of another entry.


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This pull request add's Stackbit to this Hugo theme. It add's the `stackbit.yaml` file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/hugo-coder (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- Add `stackbit.yaml` file which makes the theme work with Stackbit.
- Updated 2 posts changing `math` and `katex` from string values to booleans

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
