### PR TITLE
Adjust dark mode colorscheme

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,3 +45,4 @@
 - [Shreyansh Khajanchi](https://shreyanshja.in)
 - [Lionel Brianto](https://lionel.brianto.dev)
 - [Luis Zarate](https://github.com/jlzaratec)
+- [Ariejan de Vroom](https://www.devroom.io)

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -12,7 +12,7 @@ $link-color: #1565c0 !default;
 
 // Colors inverted
 $bg-color-inverted: #212121 !default;
-$fg-color-inverted: #fafafa !default;
+$fg-color-inverted: #dadada !default;
 $alt-bg-color-inverted: #424242 !default;
-$alt-fg-color-inverted: #fafafa !default;
-$link-color-inverted: #f44336 !default;
+$alt-fg-color-inverted: #dadada !default;
+$link-color-inverted: #36679f !default;


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

It fixes a "bug" where the inverted colorscheme was hard on the eyes with the bright whites, but having a beautiful dark-mode is a features 😄 

### Description

This PR makes the whites a bit softer and instead of inverting the blue hyperlinks to red, they're now desaturated - but still blue.

#### Before

![Screenshot 2019-10-09 at 11 09 08](https://user-images.githubusercontent.com/1913/66467874-766e4980-ea85-11e9-924d-eeb1d7494eb3.png)

#### After

![Screenshot 2019-10-09 at 11 10 07](https://user-images.githubusercontent.com/1913/66467913-89811980-ea85-11e9-9766-c716f6a62275.png)

### Issues Resolved

I just fixed this for myself, feel free to pick it up. 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

Dit this, but I think the inverted theme is not generated automatically. This might be a separate bug.

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
