### PR TITLE
Make LaTeX compatible with MathJax version 3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@
 - [Lionel Brianto](https://lionel.brianto.dev)
 - [Luis Zarate](https://github.com/jlzaratec)
 - [Ariejan de Vroom](https://www.devroom.io)
+- [Bobby Lindsey](https://github.com/bobbywlindsey)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,4 +46,4 @@
 - [Lionel Brianto](https://lionel.brianto.dev)
 - [Luis Zarate](https://github.com/jlzaratec)
 - [Ariejan de Vroom](https://www.devroom.io)
-- [Bobby Lindsey](https://github.com/bobbywlindsey)
+- [Bobby Lindsey](https://bobbywlindsey.com)

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -1,25 +1,23 @@
 {{- if .Params.math -}}
-  <script type="text/javascript" async
-    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-    MathJax.Hub.Config({
-      tex2jax: {
-        inlineMath: [['$','$']],
-        displayMath: [['$$','$$']],
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script type="text/javascript" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/startup.js" id="MathJax-script"></script>
+  <script>
+    MathJax = {
+      tex: {
+        inlineMath: [
+          ['$', '$']
+        ],
+        displayMath: [
+          ['$$', '$$']
+        ],
         processEscapes: true,
-        processEnvironments: true,
-        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-        TeX: { extensions: ["AMSmath.js", "AMSsymbols.js"] }
+        processEnvironments: true
+      },
+      options: {
+        skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
       }
-    });
-    MathJax.Hub.Queue(function() {
-      // Fix <code> tags after MathJax finishes running. This is a
-      // hack to overcome a shortcoming of Markdown. Discussion at
-      // https://github.com/mojombo/jekyll/issues/199
-      var all = MathJax.Hub.getAllJax(), i;
-      for(i = 0; i < all.length; i += 1) {
-          all[i].SourceElement().parentNode.className += ' has-jax';
-      }
-    });
+    };
   </script>
 {{- end -}}
 {{- if .Params.katex -}}


### PR DESCRIPTION
MathJax was updated to version 3 which broke the configuration blocks. `MathJax.Hub.Config()` function doesn't exists in the new version per the [mathjax docs](http://docs.mathjax.org/en/latest/upgrading/v2.html#configuration-changes).