### PR TITLE
Add \\( and \\[ as mathjax delimiters

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@
 - [José Mª Escartín](https://github.com/jme52)
 - [John Schroeder](https://blog.schroedernet.software)
 - [Tobias Lindberg](https://tobiaslindberg.com)
+- [KK](https://github.com/bebound)

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -6,10 +6,7 @@
     MathJax = {
       tex: {
         inlineMath: [
-          ['$', '$']
-        ],
-        displayMath: [
-          ['$$', '$$']
+          ['$', '$'], ['\\(', '\\)']
         ],
         processEscapes: true,
         processEnvironments: true
@@ -29,6 +26,8 @@
         delimiters: [
           {left: '$$', right: '$$', display:true},
           {left: '$', right: '$', display:false},
+          {left: '\\(', right: '\\)', display: false},
+          {left: '\\[', right: '\\]', display: true}
         ]
       }
     );">


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

`\(...\)` and `\[...\]` are widely used latex equation delimiters, so add them into delimiter option.

### Issues Resolved

Now mathjax and katex should be able to render `\\(x\\)` properly.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
