### PR TITLE
Make it possible to enable katex and mathjax globally in config.toml

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@
 - [José Mª Escartín](https://github.com/jme52)
 - [John Schroeder](https://blog.schroedernet.software)
 - [Tobias Lindberg](https://tobiaslindberg.com)
+- [KK](https://github.com/bebound)

--- a/exampleSite/content/posts/render-latex-using-katex.md
+++ b/exampleSite/content/posts/render-latex-using-katex.md
@@ -14,6 +14,8 @@ katex = "true"
 +++
 ```
 
+If you want to enable KaTeX or MathJax for all post, add `katex = ture` or `math = true` in `config.toml` in `[params]` section.
+
 It's almost a dropin alternative to the mathjax solution,you should just choose one of them.  
 
 Inline math looks like this  

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -6,10 +6,7 @@
     MathJax = {
       tex: {
         inlineMath: [
-          ['$', '$']
-        ],
-        displayMath: [
-          ['$$', '$$']
+          ['$', '$'], ['\\(', '\\)']
         ],
         processEscapes: true,
         processEnvironments: true
@@ -29,6 +26,8 @@
         delimiters: [
           {left: '$$', right: '$$', display:true},
           {left: '$', right: '$', display:false},
+          {left: '\\(', right: '\\)', display: false},
+          {left: '\\[', right: '\\]', display: true}
         ]
       }
     );">

--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -1,4 +1,4 @@
-{{- if .Params.math -}}
+{{- if or (.Params.math) (.Site.Params.math) -}}
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script type="text/javascript" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/startup.js" id="MathJax-script"></script>
@@ -17,7 +17,7 @@
     };
   </script>
 {{- end -}}
-{{- if .Params.katex -}}
+{{- if or (.Params.katex) (.Site.Params.katex) -}}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.js" integrity="sha384-2BKqo+exmr9su6dir+qCw08N2ZKRucY4PrGQPPWU1A7FtlCGjmEGFqXCv5nyM5Ij" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Make it possible to enable katex and mathjax globally in config.toml

### Issues Resolved

#240 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
