### PR TITLE
adding support for type in social links

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,3 +53,4 @@
 - [KK](https://github.com/bebound)
 - [Eli W. Hunter](https://github.com/elihunter173)
 - [Víctor López](https://github.com/viticlick)
+- [Anson VanDoren](https://github.com/anson-vandoren)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -80,6 +80,13 @@ disqusShortname = "yourdiscussshortname"
     icon = "fab fa-medium"
     weight = 5
     url = "https://medium.com/@johndoe"
+[[params.social]]
+    name = "RSS"
+    icon = "fas fa-rss"
+    weight = 6
+    url = "https://myhugosite.com/index.xml"
+    rel = "alternate"
+    type = "application/rss+xml"
 
 
 [languages]

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -10,7 +10,7 @@
       {{ range sort .}}
         {{ if .icon }}
           <li>
-            <a href="{{ .url }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }}>
+            <a href="{{ .url }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }} {{ if .type }}type="{{ .type }}"{{ end }}>
               <i class="{{ .icon }}" aria-hidden="true"></i>
             </a>
           </li>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [X] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Adds `type` attribute to social links (from config file) to allow for correct RSS links (which should have `type=application/rss+xml`

If `social.params.type` exists, add it to the generated link in the Home partial.

*Example config.toml section*
```toml
[[params.social]]
    name = "RSS"
    icon = "fas fa-rss fa-2x"
    weight = 7
    url = "https://example.com/posts/index.xml"
    rel = "alternate"
    type = "application/rss+xml"
```

See: https://developer.mozilla.org/en-US/docs/Archive/RSS/Getting_Started/Syndicating

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [X] Describe what changes are being made
- [X] Explain why and how the changes were necessary and implemented respectively
- [X] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [X] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [X] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
