### PR TITLE
Fixing grammar mistake in English reading time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,3 +54,4 @@
 - [Eli W. Hunter](https://github.com/elihunter173)
 - [Víctor López](https://github.com/viticlick)
 - [Anson VanDoren](https://github.com/anson-vandoren)
+- [Michael Lynch](https://github.com/mtlynch)

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -8,8 +8,7 @@ other = "tag"
 other = "series"
 
 [reading_time]
-one = "One minute read"
-other = "{{ .Count }} minutes read"
+other = "{{ .Count }}-minute read"
 
 [page_not_found]
 other = "Page Not Found"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This changes the reading time from "XX minutes read" to "XX-minute read".

In English, a hyphen (-) joins a number to the noun that follows it. Also, in the XX-minute construction, "minute" remains singular regardless of the number ('1-minute' and '2-minute' are correct, whereas '2-minutes' is incorrect).

Reference: https://www.grammarly.com/blog/hyphen/

>When numbers are used as the first part of a compound adjective, use a hyphen to connect them to the noun that follows them. This way, the reader knows that both words function like a unit to modify another noun. This applies whether the number is written in words or in digits.
>Example: The president of the company gave a 10-minute speech to the Board of Directors.

### Issues Resolved

*None*

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
