### PR TITLE
Hide hamburger menu button on mobile when there are no menu items

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,6 +3,7 @@
     <a class="navigation-title" href="{{ .Site.BaseURL | relLangURL }}">
       {{ .Site.Title }}
     </a>
+    {{ if or .Site.Menus.main .Site.IsMultiLingual }}
     <input type="checkbox" id="menu-toggle" />
     <label class="menu-button float-right" for="menu-toggle"><i class="fas fa-bars"></i></label>
     <ul class="navigation-list">
@@ -31,5 +32,6 @@
         {{ end }}
       {{ end }}
     </ul>
+  {{ end }}
   </section>
 </nav>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,6 +32,6 @@
         {{ end }}
       {{ end }}
     </ul>
-  {{ end }}
+    {{ end }}
   </section>
 </nav>


### PR DESCRIPTION
Fix #253

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

It hides the hamburger menu button on mobile if there are no menu items. It achieves this by moving the with template condition to before the input html tag which ensures that if there are no menu.main items, the contents of the conditional are block are not generated.

### Issues Resolved

#253

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
