### PR TITLE
Add support for Fathom Analytics

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,3 +56,4 @@
 - [Anson VanDoren](https://github.com/anson-vandoren)
 - [Michael Lynch](https://github.com/mtlynch)
 - [FIGBERT](https://figbert.com/)
+- [Yash Mehrotra](https://yashmehrotra.com)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -50,6 +50,11 @@ disqusShortname = "yourdiscussshortname"
     # Custom JS
     custom_js = []
 
+# If you want to use fathom(https://usefathom.com) for analytics, add this section
+[params.fathomAnalytics]
+    siteID = "ABCDE"
+    rootURL = "analytics.example.com"
+
 [taxonomies]
   category = "categories"
   series = "series"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,7 +53,8 @@ disqusShortname = "yourdiscussshortname"
 # If you want to use fathom(https://usefathom.com) for analytics, add this section
 [params.fathomAnalytics]
     siteID = "ABCDE"
-    rootURL = "analytics.example.com"
+    # Default value is cdn.usefathom.com, overwrite this if you are self-hosting
+    serverURL = "analytics.example.com"
 
 [taxonomies]
   category = "categories"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -108,6 +108,10 @@
 
     {{ template "_internal/google_analytics.html" . }}
 
+    {{ if .Site.Params.fathomAnalytics }}
+      {{- partial "analytics/fathom" . -}}
+    {{ end }}
+
   </body>
 
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -108,7 +108,7 @@
 
     {{ template "_internal/google_analytics.html" . }}
 
-    {{ if .Site.Params.fathomAnalytics }}
+    {{ if .Site.Params.fathomAnalytics.siteID }}
       {{- partial "analytics/fathom" . -}}
     {{ end }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -108,7 +108,7 @@
 
     {{ template "_internal/google_analytics.html" . }}
 
-    {{ if .Site.Params.fathomAnalytics.siteID }}
+    {{ if and .Site.Params.fathomAnalytics .Site.Params.fathomAnalytics.siteID }}
       {{- partial "analytics/fathom" . -}}
     {{ end }}
 

--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -1,0 +1,13 @@
+<script>
+(function(f, a, t, h, o, m){
+	a[h]=a[h]||function(){
+		(a[h].q=a[h].q||[]).push(arguments)
+	};
+	o=f.createElement('script'),
+	m=f.getElementsByTagName('script')[0];
+	o.async=1; o.src=t; o.id='fathom-script';
+	m.parentNode.insertBefore(o,m)
+})(document, window, '//{{ .Site.Params.fathomAnalytics.rootURL }}/tracker.js', 'fathom');
+fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
+fathom('trackPageview');
+</script>

--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -7,7 +7,7 @@
 	m=f.getElementsByTagName('script')[0];
 	o.async=1; o.src=t; o.id='fathom-script';
 	m.parentNode.insertBefore(o,m)
-})(document, window, '//{{ .Site.Params.fathomAnalytics.rootURL }}/tracker.js', 'fathom');
+})(document, window, '//{{ .Site.Params.fathomAnalytics.serverURL | default "cdn.usefathom.com" }}/tracker.js', 'fathom');
 fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
 fathom('trackPageview');
 </script>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Have added support for Fathom Analytics (https://usefathom.com/). Fathom is a privacy-first site analytics tool. I implemented this because hugo only provides out of the box support for Google Analytics. There are very few themes which support other analytics tools as well.

### Issues Resolved

Fix for #263 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
