### PR TITLE
Adding gravatar support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,4 @@
 - [FIGBERT](https://figbert.com/)
 - [Yash Mehrotra](https://yashmehrotra.com)
 - [Paolo Mainardi](https://paolomainardi.com)
+- [Ka-Wai Lin](https://github.com/kwlin)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,7 @@ disqusShortname = "yourdiscussshortname"
     keywords = "blog,developer,personal"
     info = "Full Stack DevOps and Magician"
     avatarurl = "images/avatar.jpg"
+    #gravatar = "john.doe@example.com"
     footercontent = "Enter a text here."
 
     dateformat = "January 2, 2006"

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -1,7 +1,12 @@
 <section class="container centered">
   <div class="about">
-    {{ with .Site.Params.avatarurl }}
-      <div class="avatar"><img src="{{ . | relURL }}" alt="avatar"></div>
+    {{ if and (isset .Site.Params "avatarurl") (not (isset .Site.Params "gravatar")) }}
+      {{ with .Site.Params.avatarurl }}
+        <div class="avatar"><img src="{{ . | relURL }}" alt="avatar"></div>
+      {{ end }}
+    {{ end }}
+    {{ with .Site.Params.gravatar }}
+      <div class="avatar"><img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" alt="gravatar"></div>
     {{ end }}
     <h1>{{ .Site.Params.author }}</h1>
     <h2>{{ .Site.Params.info }}</h2>


### PR DESCRIPTION
Adding gravatar as an alternative avatar

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Adds Gravatar as an alternative way for avatar image. Implementation is inspired by hyde-hyde theme.

When both gravatar and avatar url params have been provided, then gravatar will be used.

### Issues Resolved

- 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
