### PR TITLE
Adds `.Content` to list.html partial

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@
 - [Piotr Orzechowski](https://orzechowski.tech)
 - [Glenn Feunteun](https://github.com/gfeun)
 - [Santiago González](https://github.com/netrules)
+- [Codruț Constantin Gușoi](https://www.sdwolfz.pro)

--- a/exampleSite/content/snippets/_index.md
+++ b/exampleSite/content/snippets/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Snippets"
+---
+
+This content is in `content/snippets/_index.md`

--- a/exampleSite/content/snippets/first/index.md
+++ b/exampleSite/content/snippets/first/index.md
@@ -1,0 +1,9 @@
+---
+title: "First snippet"
+---
+
+This content is in `snippets/first/index.md`
+
+```sh
+pwd
+```

--- a/exampleSite/content/snippets/second/index.md
+++ b/exampleSite/content/snippets/second/index.md
@@ -1,0 +1,9 @@
+---
+title: "Second snippet"
+---
+
+This content is in `snippets/second/index.md`
+
+```sh
+ls -la
+```

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -7,6 +7,7 @@
 
     {{- .Title -}}
   </h1>
+  {{ .Content }}
   <ul>
     {{ range .Paginator.Pages }}
     <li>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description
Adds `{{.Content}}` to `list.html` partial. This is done to allow adding content to lists using a `_index.md` file in a sub-directory.

Previously there was no way to add this content and you needed to overwrite the layout and partial to achieve this.



