### PR TITLE
navigation to different language version remains on page

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
       {{ if .Site.IsMultiLingual }}
         {{ $node := . }}
         {{ .Scratch.Set "separator" true }}
-        {{ range .Site.Home.AllTranslations }}
+        {{ range .Translations }}
           {{ if ne $.Site.Language .Language }}
             {{ if $node.Scratch.Get "separator" }}
               <li class="navigation-item menu-separator">


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Language links are only displayed for those languages which offer a translation of the current page. When clicked you navigate to the same page in the translated version rather than always returning to the home page.

### Issues Resolved

#293

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [#293 ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
