### PR TITLE
Support SEO friendly meta tags

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,3 +64,4 @@
 - [Santiago González](https://github.com/netrules)
 - [Codruț Constantin Gușoi](https://www.sdwolfz.pro)
 - [Clément Pannetier](https://clementpannetier.dev)
+- [FantasticMao](https://github.com/FantasticMao)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
-    {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
-    {{ with .Site.Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
+    <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}{{ else }}{{ .Site.Params.description }}{{ end }}{{ end }}">
+    <meta name="keywords" content="{{ with .Keywords }}{{ delimit . "," }}{{ else }}{{ if .IsPage }}{{ with .Params.keywords }}{{ delimit . "," }}{{ else }}{{ .Site.Params.keywords }}{{ end }}{{ else }}{{ .Site.Params.keywords }}{{ end }}{{ end }}">
 
     {{ template "_internal/twitter_cards.html" . }}
     {{ template "_internal/opengraph.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
-    <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}{{ else }}{{ .Site.Params.description }}{{ end }}{{ end }}">
-    <meta name="keywords" content="{{ with .Keywords }}{{ delimit . "," }}{{ else }}{{ if .IsPage }}{{ with .Params.keywords }}{{ delimit . "," }}{{ else }}{{ .Site.Params.keywords }}{{ end }}{{ else }}{{ .Site.Params.keywords }}{{ end }}{{ end }}">
+    <meta name="description" content="{{ .Description | default (.Summary | default .Site.Params.description ) }}">
+    <meta name="keywords" content="{{ (delimit .Keywords ",") | default .Site.Params.keywords }}">
 
     {{ template "_internal/twitter_cards.html" . }}
     {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Support two SEO friendly tags: `<meta name="description">` and `<meta name="keywords">`.

Because of the following code snippet, the meta tag `<meta name="description">` and `<meta name="keywords">` on the website will use the Hugo site variables on every page, and that is actually not SEO friendly.

https://github.com/luizdepra/hugo-coder/blob/acb4bf6f2dcce51a27dc0e1f1008afb369d378d8/layouts/_default/baseof.html#L9-L10

I have rewritten this code snippet, and hope to use such a strategy:

```html
{{ with .Description }}
  <meta name="description" content="{{ . }}">
{{ else }}
  {{ if .IsPage }}
    {{ with .Params.description }}
      <meta name="description" content="{{ . }}">
    {{ else }}
      <meta name="description" content="{{ .Summary }}">
    {{ end }}
  {{ else }}
    <meta name="description" content="{{ .Site.Params.description }}">
  {{ end }}
{{ end }}

{{ with .Keywords }}
  <meta name="keywords" content="{{ delimit . "," }}">
{{ else }}
  {{ if .IsPage }}
    {{ with .Params.keywords }}
      <meta name="keywords" content="{{ delimit . "," }}">
    {{ else }}
      <meta name="keywords" content="{{ .Site.Params.keywords }}">
    {{ end }}
  {{ else }}
    <meta name="keywords" content="{{ .Site.Params.keywords }}">
  {{ end }}
{{ end }}
```

### Issues Resolved

#299 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already