### PR TITLE
Add MathJax to other types of pages, not just posts.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,4 +3,5 @@
 {{ end }}
 {{ define "content" }}
   {{ partial "page.html" . }}
+  {{ partial "posts/math.html" . }}
 {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

First, thanks for your great theme. In my page, I use MathJax to generate LaTeX equations, but in the default configuration, only the pages in "posts" have the LaTeX equations generated. I add the math.html also to the default to add to other pages.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
