### PR TITLE
Fall back to index if translation for the page doesn't exist

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
       {{ if .Site.IsMultiLingual }}
         {{ $node := . }}
         {{ .Scratch.Set "separator" true }}
-        {{ range .Translations }}
+        {{ range (default .Site.Home.AllTranslations .Translations) }}
           {{ if ne $.Site.Language .Language }}
             {{ if $node.Scratch.Get "separator" }}
               <li class="navigation-item menu-separator">


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This is an enhancement follow up directly over #294, in which language menu gets removed if there's no translation for that particular page existed. This PR constructs the language menu as follow:

- first tries to look up a translation for the page and use a PermaLink of it
- if translation wasn't found falls back to the link for the index page in the said language

Example, being in "English" version:

| Page                         | Translation | Menu Name | Menu Link |
|-----------------------------|----------------|------------------|----------------|
| `/`                               | Yes            | French         | `/fr/`           |
| `/about/`                     | Yes            | French         | `/fr/about/` |
| `/posts/`                      | Yes           | French         | `/fr/posts/`  |
| `/posts/hello-world/`  | No            | French         | `/fr/`            |

### Issues Resolved

Related to #293 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
