### PR TITLE
Improve privacy by supporting gravatar MD5 hashes.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,3 +66,4 @@
 - [Clément Pannetier](https://clementpannetier.dev)
 - [FantasticMao](https://github.com/FantasticMao)
 - [Utkarsh Gupta](https://utkarsh2102.com)
+- [Thomas Kenvin](https://github.com/tkenvin)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,8 +20,19 @@ disqusShortname = "yourdiscussshortname"
     description = "John Doe's personal website"
     keywords = "blog,developer,personal"
     info = "Full Stack DevOps and Magician"
+    
+    # Specify the image on the home page
+    # if nothing is specified then nothing is shown
+    # otherwise an image is chosen in the order:
+    # gravatar > avatarurl > gravatarmd5
+    # avatarurl is a locally hosted image
     avatarurl = "images/avatar.jpg"
+    # gravatar is the email address you use for gravatar
     #gravatar = "john.doe@example.com"
+    # gravatarmd5 is the MD5 hash of your gravatar email
+    # use this if you don't want to put your email address in git 
+    #gravatarmd5 = "8eb1b522f60d11fa897de1dc6351b7e8"
+
     footercontent = "Enter a text here."
 
     dateformat = "January 2, 2006"

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -1,12 +1,17 @@
 <section class="container centered">
   <div class="about">
-    {{ if and (isset .Site.Params "avatarurl") (not (isset .Site.Params "gravatar")) }}
+    {{ if (isset .Site.Params "gravatar") }}
+      {{ with .Site.Params.gravatar }}
+        <div class="avatar"><img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" alt="gravatar"></div>
+      {{ end }}
+    {{ else if (isset .Site.Params "avatarurl") }}
       {{ with .Site.Params.avatarurl }}
         <div class="avatar"><img src="{{ . | relURL }}" alt="avatar"></div>
       {{ end }}
-    {{ end }}
-    {{ with .Site.Params.gravatar }}
-      <div class="avatar"><img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" alt="gravatar"></div>
+    {{ else if (isset .Site.Params "gravatarmd5") }}
+      {{ with .Site.Params.gravatarmd5 }}
+        <div class="avatar"><img src="https://www.gravatar.com/avatar/{{ . }}?s=240&d=mp" alt="gravatar"></div>
+      {{ end }}
     {{ end }}
     <h1>{{ .Site.Params.author }}</h1>
     <h2>{{ .Site.Params.info }}</h2>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Allows the site owner to use the pre-calculated MD5 hash instead of their email address for gravatar.

This improves privacy for the site owner if they want their site in a public repository but do not want their email address to be known.

The change is implemented by the addition of a new configuration parameter and a change to the logic when calculating the avatar image to use.

### Issues Resolved

This does not resolve any reported issue.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
