### PR TITLE
Allow internationalization for 'Posts'

### DIFF
--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -3,7 +3,13 @@
 {{ end }}
 {{ define "content" }}
   <section class="container list">
-    <h1 class="title">{{ .Title }}</h1>
+    <h1 class="title">
+      {{- if i18n .Title}}
+        {{- i18n .Title }}
+      {{ else }}
+        {{- .Title }}
+      {{ end }}
+    </h1>
 
     <ul>
       {{- range .Paginator.Pages -}}

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,16 +1,9 @@
 {{ define "title" }}
-  {{ .Title }} · {{ .Site.Title }}
+  {{ i18n (lower .Title) | default .Title }} · {{ .Site.Title }}
 {{ end }}
 {{ define "content" }}
   <section class="container list">
-    <h1 class="title">
-      {{- if i18n .Title}}
-        {{- i18n .Title }}
-      {{ else }}
-        {{- .Title }}
-      {{ end }}
-    </h1>
-
+    <h1 class="title"> {{ i18n (lower .Title) | default .Title }} </h1>
     <ul>
       {{- range .Paginator.Pages -}}
         {{- .Render "li" -}}


### PR DESCRIPTION
### Prerequisites

- [x] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Allows for customization in the internationalization files for "Posts". 

If there is an entry in the `i18n/` files under 'Posts' (Uppercase P), it will be used in the `posts` page. 
If not, it will revert to what would've been displayed instead, and not create a breaking change.

**NOTE** While this is NOT a breaking change, we still need to update the `i18n/` files for the changes to reflect.

### Issues Resolved

How to change /posts page title? #70 
i18n translation used in layout files #237
