### PR TITLE
Use title case for 'posts' translation

### DIFF
--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,9 +1,9 @@
 {{ define "title" }}
-  {{ i18n (lower .Title) | default .Title }} · {{ .Site.Title }}
+  {{ title (i18n (lower .Title)) | default .Title }} · {{ .Site.Title }}
 {{ end }}
 {{ define "content" }}
   <section class="container list">
-    <h1 class="title"> {{ i18n (lower .Title) | default .Title }} </h1>
+    <h1 class="title"> {{ title (i18n (lower .Title)) | default .Title }} </h1>
     <ul>
       {{- range .Paginator.Pages -}}
         {{- .Render "li" -}}


### PR DESCRIPTION
### Prerequisites

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Previously having this entry in the example site `i18n/pt-br.toml`.
```toml
[posts]
other = "posts in portuguese"
```
Was displayed _posts in portuguese_ i.e. no capitalization.

This change uses [title case](https://gohugo.io/functions/title/), so the entry is displayed as _Posts in Portuguese_. Note the lower case _in_.

### Issues Resolved

This issue was kindly reported by @a1x42 [here](https://github.com/luizdepra/hugo-coder/pull/337#issuecomment-631943516).