### PR TITLE
WIP: Support for showing Post summary and featured_image in Post List

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -55,6 +55,12 @@ disqusShortname = "yourdiscussshortname"
     # Custom JS
     custom_js = []
 
+    # Show a summary of each Post in the Posts list
+    showPostSummaryInPostList = false
+
+    # Show the featured image of each Post in the Posts list
+    showFeaturedImageInPostList = true
+
 # If you want to use fathom(https://usefathom.com) for analytics, add this section
 [params.fathomAnalytics]
     siteID = "ABCDE"

--- a/layouts/posts/li.html
+++ b/layouts/posts/li.html
@@ -1,4 +1,14 @@
-<li>
-  <span class="date">{{ .Date.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</span>
-  <a class="title" href="{{ .Params.ExternalLink | default .RelPermalink }}">{{ .Title }}</a>
+<li style="display: flex; flex-direction: row;">
+  <div>
+    <span class="date">{{ .Date.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</span>
+  </div>
+  <div>
+    <a class="title" href="{{ .Params.ExternalLink | default .RelPermalink }}">{{ .Title }}</a>
+    {{ if and .Params.featured_image .Site.Params.showFeaturedImageInPostList }}
+      <a href="{{ .Params.ExternalLink | default .RelPermalink }}" class="image featured" alt="{{ .Title }}"><img src="{{ index .Params "featured_image" }}"></a>
+    {{ end }}
+    {{ if .Site.Params.showPostSummaryInPostList }}
+      <p>{{ .Summary }}</p>
+    {{ end }}
+  </div>
 </li>


### PR DESCRIPTION
I hope it's ok to submit an unsolicited PR. This is also my first attempt at modifying a Hugo theme so let me know if this isn't how it should be done.  😀

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This change would allow the user to show a summary and/or `featured_image` for a Post in the Posts list. This would be user configurable with the options `params.showPostSummaryInPostList` and `params.showFeaturedImageInPostList` - the default would be to have these options turned off.

This scratches a particular itch I have but understand if this goes against the 'simple and clean' ethos of this project.

If this change is seen as a good idea I would:

* Move the CSS changes to the SCSS files
* Get people's opinions on whether this should be for all lists or just the Posts list
* Update the wiki to document the new options

#### Examples

```toml
[params]
params.showFeaturedImageInPostList = true
params.showPostSummaryInPostList = false
```

![Screen Shot 2020-06-02 at 12 17 15 pm](https://user-images.githubusercontent.com/23428238/83472950-d1005e00-a4cb-11ea-827d-cecde88366e2.png)

```toml
params.showFeaturedImageInPostList = true
params.showPostSummaryInPostList = true
```

![Screen Shot 2020-06-02 at 12 18 03 pm](https://user-images.githubusercontent.com/23428238/83472954-d362b800-a4cb-11ea-8425-55b28bc33db6.png)


### Issues Resolved

Nil

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [X] Describe what changes are being made
- [X] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
