### PR TITLE
Add support for plausible analytics

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,3 +71,4 @@
 - [Endormi](https://endormi.io)
 - [Rajiv Ranjan Singh](https://iamrajiv.github.io/)
 - [Pakhomov Alexander](https://github.com/PakhomovAlexander)
+- [Rhys Perry](https://rhysperry.com)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -60,6 +60,12 @@ disqusShortname = "yourdiscussshortname"
     siteID = "ABCDE"
     # Default value is cdn.usefathom.com, overwrite this if you are self-hosting
     serverURL = "analytics.example.com"
+    
+# If you want to use plausible(https://plausible.io) for analytics, add this section
+[params.plausibleAnalytics]
+    domain = "example.com"
+    # Default value is plausible.io, overwrite this if you are self-hosting or using a custom domain
+    serverURL = "analytics.example.com"
 
 [taxonomies]
   category = "categories"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -119,6 +119,10 @@
       {{- partial "analytics/fathom" . -}}
     {{ end }}
 
+    {{ if and .Site.Params.plausibleAnalytics .Site.Params.plausibleAnalytics.domain }}
+      {{- partial "analytics/plausible" . -}}
+    {{ end }}
+
   </body>
 
 </html>

--- a/layouts/partials/analytics/plausible.html
+++ b/layouts/partials/analytics/plausible.html
@@ -1,15 +1,1 @@
-<script>
-(function(f, a, t, h, o, m){
-	a[h]=a[h]||function(){
-		(a[h].q=a[h].q||[]).push(arguments)
-	};
-	o=f.createElement('script'),
-	m=f.getElementsByTagName('script')[0];
-	o.async=1; o.src=t; o.id='fathom-script';
-	m.parentNode.insertBefore(o,m)
-})(document, window, '//{{ .Site.Params.fathomAnalytics.serverURL | default "cdn.usefathom.com" }}/tracker.js', 'fathom');
-fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
-fathom('trackPageview');
-</script>
-
 <script async defer data-domain=”{{ .Site.Params.plausibleAnalytics.domain }}” src=”https://{{ .Site.Params.plausibleAnalytics.serverURL | default "plausible.io" }}/js/index.js”></script> 

--- a/layouts/partials/analytics/plausible.html
+++ b/layouts/partials/analytics/plausible.html
@@ -1,0 +1,15 @@
+<script>
+(function(f, a, t, h, o, m){
+	a[h]=a[h]||function(){
+		(a[h].q=a[h].q||[]).push(arguments)
+	};
+	o=f.createElement('script'),
+	m=f.getElementsByTagName('script')[0];
+	o.async=1; o.src=t; o.id='fathom-script';
+	m.parentNode.insertBefore(o,m)
+})(document, window, '//{{ .Site.Params.fathomAnalytics.serverURL | default "cdn.usefathom.com" }}/tracker.js', 'fathom');
+fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
+fathom('trackPageview');
+</script>
+
+<script async defer data-domain=”{{ .Site.Params.plausibleAnalytics.domain }}” src=”https://{{ .Site.Params.plausibleAnalytics.serverURL | default "plausible.io" }}/js/index.js”></script> 

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -114,6 +114,16 @@ models:
               - type: string
                 name: serverURL
                 label: URL for Fathom Analytics
+          - type: object
+            name: plausibleAnalytics
+            label: Plausible Analytics (optional)
+            fields:
+              - type: string
+                name: domain
+                label: Website domain for Plausible Analytics
+              - type: string
+                name: serverURL
+                label: URL for Plausible Analytics
       - type: object
         name: languages
         fields:


### PR DESCRIPTION
This PR should add support for [plausible](https://plausible.io) analytics.

It is just a modified copy of the PR that implemented fathom analytics