### PR TITLE
Switch to jsdelivr for js and css

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,3 +73,4 @@
 - [Pakhomov Alexander](https://github.com/PakhomovAlexander)
 - [Rhys Perry](https://rhysperry.com)
 - [Arunvel Sriram](https://github.com/arunvelsriram)
+- [Rabin Adhikari](https://github.com/rabinadk1/)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
     <meta name="keywords" content="{{ (delimit .Keywords ",") | default .Site.Params.keywords }}">
 
     {{ if .Site.Params.enableTwemoji }}
-      <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/npm/twemoji@13/dist/twemoji.npm.min.js"></script>
     {{ end }}
 
     {{ template "_internal/twitter_cards.html" . }}
@@ -27,8 +27,7 @@
     {{ end }}
 
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700%7CMerriweather:300,700%7CSource+Code+Pro:400,700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" integrity="sha384-Bfad6CLCknfcloXFOyFnlgtENryhrpZCe29RTifKEixXQZ38WheV+i/6YWSzkz3V" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/@fortawesome/fontawesome-free@5/css/all.min.css,npm/normalize.css@8">
 
     {{ if .Site.IsServer }}
       {{ $cssOpts := (dict "targetPath" "css/coder.css" "enableSourceMap" true ) }}


### PR DESCRIPTION
Switched to jsdelivr for nomalize.css, fontawesome, and twemoji and added version aliasing which enables auto-update of minor versions. Combined fontawesome and normalize into one request.

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces a breaking change.

### Description

This achieves better CDN support and less number of requests. Additionally, it uses the minimized version of fontawesome CSS.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
