### PR TITLE
Add Option To Hide Color Scheme Toggle

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,3 +77,4 @@
 - [Jared Sturdy](https://github.com/jsturdy)
 - [Daniel Monteiro](https://github.com/dfamonteiro)
 - [Dave Rolsky](https://github.com/autarch)
+- [Joseph Sanders](https://github.com/jls83)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,6 +42,9 @@ disqusShortname = "yourdiscussshortname"
     # "light" (light background, dark foreground) (default)
     colorscheme = "auto"
 
+    # Hide the toggle button, along with the associated vertical divider
+    hidecolorschemetoggle = false
+
     # Series see also post count
     maxSeeAlsoItems = 5
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,9 +4,11 @@
       {{ .Site.Title }}
     </a>
     {{ if or .Site.Menus.main .Site.IsMultiLingual }}
-      <span id="dark-mode-toggle" class="float-right">
-        <i class="fa fa-adjust fa-fw" aria-hidden="true"></i>
-      </span>
+      {{ if not .Site.Params.hidecolorschemetoggle }}
+        <span id="dark-mode-toggle" class="float-right">
+          <i class="fa fa-adjust fa-fw" aria-hidden="true"></i>
+        </span>
+      {{ end }}
       <input type="checkbox" id="menu-toggle" />
       <label class="menu-button float-right" for="menu-toggle">
         <i class="fa fa-bars fa-fw" aria-hidden="true"></i>
@@ -36,9 +38,11 @@
             {{ end }}
           {{ end }}
         {{ end }}
-        <li class="navigation-item separator">
-          <span>|</span>
-        </li>
+        {{ if not .Site.Params.hidecolorschemetoggle }}
+          <li class="navigation-item separator">
+            <span>|</span>
+          </li>
+        {{ end }}
       </ul>
     {{ end }}
   </section>

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -66,6 +66,8 @@ models:
             name: hideCredits
           - type: boolean
             name: hideCopyright
+          - type: boolean
+            name: hidecolorschemetoggle
           - type: number
             name: since
           - type: string


### PR DESCRIPTION
### Prerequisites
Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description
Adds a new `hidedarkmodetoggle` option to the `params` section of `config.toml`. This conditionally shows/hides the `dark-mode-toggle` `span` tag in the site header (along with the associated vertical separator) if the user wants to lock-down the color scheme of their site.

#### Contributors
- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already