### PR TITLE
Use relative URLs everywhere and remove <base> tag

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,4 @@
 - [Lorenzo Cameroni](https://github.com/came88)
 - [Jared Sturdy](https://github.com/jsturdy)
 - [Daniel Monteiro](https://github.com/dfamonteiro)
+- [Dave Rolsky](https://github.com/autarch)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,7 +7,6 @@ languagecode = "en"
 defaultcontentlanguage = "en"
 
 paginate = 20
-canonifyurls = true
 
 pygmentsstyle = "b2"
 pygmentscodefences = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,9 +17,6 @@
     {{ template "_internal/twitter_cards.html" . }}
     {{ template "_internal/opengraph.html" . }}
 
-    {{ if .Permalink }}
-      <base href="{{ .Permalink }}">
-    {{ end }}
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
 
     {{ if .Permalink }}
@@ -80,14 +77,14 @@
       {{ end }}
     {{ end }}
 
-    <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_32 | default "/images/favicon-32x32.png" | absURL }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_16 | default "/images/favicon-16x16.png" | absURL }}" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_32 | default "/images/favicon-32x32.png" | relURL }}" sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ .Site.Params.favicon_16 | default "/images/favicon-16x16.png" | relURL }}" sizes="16x16">
 
-    <link rel="apple-touch-icon" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | absURL }}">
-    <link rel="apple-touch-icon"  sizes="180x180" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | absURL }}">
+    <link rel="apple-touch-icon" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
+    <link rel="apple-touch-icon"  sizes="180x180" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
 
     {{ range .AlternativeOutputFormats -}}
-      {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+      {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
     {{ end -}}
 
     {{ hugo.Generator }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
         {{ with .Site.Menus.main}}
           {{ range sort . }}
             <li class="navigation-item">
-              <a class="navigation-link" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
+              <a class="navigation-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
             </li>
           {{ end }}
         {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

There were a few places still using absolute URLs, including `<link rel="icon">` tags, `<link rel="alternate">` tags, and nav menu links. In addition, the presence of a `<base>` tag caused the browser to absolute-ize all relative URLs.

This is a problem for things like render.com, which will put the site on its own domain for previews. For example, I have a preview site at https://houseabsolute-com.onrender.com/. Ultimately this will be served at https://houseabsolute.com/, but before I switched over I wanted to preview the site.

The absolute URLs were being generated for https://houseabsolute.com/ because of my baseURL setting in config and the presence of the <base> tag. This completely breaks the preview site.

### Issues Resolved

None that I could find.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
