### PR TITLE
Fix darkModeToggle javascript error

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -109,12 +109,14 @@
       {{ partial "footer.html" . }}
     </main>
 
-    {{ if .Site.IsServer }}
-      {{ $script := resources.Get "js/dark-mode.js" }}
-      <script src="{{ $script.RelPermalink }}"></script>
-    {{ else }}
-      {{ $script := resources.Get "js/dark-mode.js" | minify | fingerprint }}
-      <script src="{{ $script.RelPermalink }}"></script>
+    {{ if not .Site.Params.hidecolorschemetoggle }}
+      {{ if .Site.IsServer }}
+        {{ $script := resources.Get "js/dark-mode.js" }}
+        <script src="{{ $script.RelPermalink }}"></script>
+      {{ else }}
+        {{ $script := resources.Get "js/dark-mode.js" | minify | fingerprint }}
+        <script src="{{ $script.RelPermalink }}"></script>
+      {{ end }}
     {{ end }}
 
     {{ range .Site.Params.customJS }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

Disabling the dark mode switcher leaves around the javascript file, which throws an error:

```
Uncaught TypeError: darkModeToggle is null
    <anonymous> http://localhost:1313/js/dark-mode.js:14
```

With this change the javascript file is removed when disabling the switcher.