### PR TITLE
Update Japanese translation

### DIFF
--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -10,6 +10,9 @@ other = "シリーズ"
 [author]
 other = "筆者"
 
+[posts]
+other = "記事"
+
 [reading_time]
 one = "1分で読めます"
 other = "{{ .Count }}分で読めます"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -7,6 +7,9 @@ other = "タグ"
 [series]
 other = "シリーズ"
 
+[author]
+other = "筆者"
+
 [reading_time]
 one = "1分で読めます"
 other = "{{ .Count }}分で読めます"
@@ -18,7 +21,10 @@ other = "ページが見つかりません"
 other = "申し訳ございません。アクセスしようとしたページが見つかりませんでした。"
 
 [head_back]
-other = "<a href=\"{{ . }}\">ホームページ</a>からお探しいただきますようお願い申し上げます。"
+other = "<a href=\"{{ . }}\">トップページ</a>からお探しいただきますようお願い申し上げます。"
 
 [powered_by]
 other = "利用技術"
+
+[see_also]
+other = "関連記事："


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Add Japanese translations.

1. Author
2. "See also in" sentence structure doesn't work in Japanese so I made it as "Related articles: "
3. Updated "Homepage" to "Top page" which is a more common way of saying home page in Japanese.
4. Added posts (記事 can mean both articles and posts), 投稿 can also be a translation here (literal translation: post submission) but considering that this is being used as a post type, it should be 記事 instead. Thanks for the [explanation](https://github.com/luizdepra/hugo-coder/issues/417#issuecomment-717421545), @clement-pannetier.

### Issues Resolved

Resolves one of the item in #417 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
