### PR TITLE
Add missing translations for en and pt-br

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -10,6 +10,9 @@ other = "series"
 [author]
 other = "author"
 
+[posts]
+other = "posts"
+
 [reading_time]
 one = "One-minute read"
 other = "{{ .Count }}-minute read"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -7,6 +7,12 @@ other = "tag"
 [series]
 other = "séries"
 
+[author]
+other = "autor"
+
+[posts]
+other = "artigos"
+
 [reading_time]
 one = "Um minuto de leitura"
 other = "{{ .Count }} minutos de leitura"


### PR DESCRIPTION
Add missing translations ofr `en` and `pt-br`.

(I'm going to stop pushing changes directly to `master`. I want to give a better visibility of all the changes I do.)