### PR TITLE
Add more Romanian translations

### DIFF
--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -7,6 +7,12 @@ other = "etichetă"
 [series]
 other = "serie"
 
+[author]
+other = "autor"
+
+[posts]
+other = "articole"
+
 [reading_time]
 one   = "Un minut de lectură"
 other = "{{ .Count }} {{ if lt .Count 20 }}minute{{ else }}de minute{{ end }} de lectură"
@@ -22,3 +28,6 @@ other = "Poți să te întorci la <a href=\"{{ . }}\">pagina principală</a>."
 
 [powered_by]
 other = "Susținut de"
+
+[see_also]
+other = "Altele din seria"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Refs: https://github.com/luizdepra/hugo-coder/issues/417

Add missing Romanian translations. For `see_also` it literally translates to "Other from series", I did not want to use the taxonomy name there but it does not sound good without it, compared to English where "Other from" works well without specifying that the next element after that is part of a series. Language quirks... 
