### PR TITLE
Add i18n support for Korean

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,3 +87,4 @@
 - [TMineCola](https://github.com/tminecola)
 - [Arafat Hasan](https://github.com/arafat-hasan)
 - [YUJI](https://yuji.ne.jp/)
+- [JaeSang Yoo](https://github.com/JSYoo5B)

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,33 @@
+[category]
+other = "카테고리"
+
+[tag]
+other = "태그"
+
+[series]
+other = "시리즈"
+
+[author]
+other = "저자"
+
+[posts]
+other = "포스트"
+
+[reading_time]
+one = "읽는데 1분"
+other = "읽는데 {{ .Count }}분"
+
+[page_not_found]
+other = "페이지를 찾을 수 없습니다."
+
+[page_does_not_exist]
+other = "해당 페이지가 존재하지 않습니다."
+
+[head_back]
+other = "<a href=\"{{ . }}\">홈페이지</a>로 돌아가기"
+
+[powered_by]
+other = "Powered by"
+
+[see_also]
+other = "관련 글:"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Add i18n file for Korean. (Copied i18n template from en.toml)

* **powered_by** hasn't translated.
  * Using this kind of short English in footer may acceptable for Korean users
  * I figured out it stands for the text in the footer, **Powered by Hugo & Coder**
    And If I have to force translate, I'd suggest to change some layout for texts.
    In Korean, word order is different from English or the others.

* For Korean understanding contributors
  * **powered_by**는 번역하지 않았습니다.
    이 정도 영어는 번역 안해도 용인 가능한 수준이라 판단했습니다.
  * 굳이 번역하자면 **Hugo & Coder로 제작된 사이트**가 적합해 보이는데,
    이를 위해선 어순이 변경되어야 하므로 해당 텍스트의 양식을 바꾸는 것을 제안했습니다.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
