### PR TITLE
Add support of Cloudflare Web Analytics

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -76,6 +76,10 @@ disqusShortname = "yourdiscussshortname"
 [params.goatCounter]
     code = "code"
 
+# If you want to use  Cloudflare Web Analytics(https://cloudflare.com) for analytics, add this section
+[params.cloudflare]
+    token = "token"
+
 [taxonomies]
   category = "categories"
   series = "series"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -76,7 +76,7 @@ disqusShortname = "yourdiscussshortname"
 [params.goatCounter]
     code = "code"
 
-# If you want to use  Cloudflare Web Analytics(https://cloudflare.com) for analytics, add this section
+# If you want to use Cloudflare Web Analytics(https://cloudflare.com) for analytics, add this section
 [params.cloudflare]
     token = "token"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -136,6 +136,10 @@
     {{ if and .Site.Params.goatCounter .Site.Params.goatCounter.code }}
       {{- partial "analytics/goatcounter" . -}}
     {{ end }}
+
+    {{ if and .Site.Params.cloudflare .Site.Params.cloudflare.token }}
+      {{- partial "analytics/cloudflare" . -}}
+    {{ end }}
   </body>
 
 </html>

--- a/layouts/partials/analytics/cloudflare.html
+++ b/layouts/partials/analytics/cloudflare.html
@@ -1,0 +1,4 @@
+<!-- Cloudflare Web Analytics -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js'
+        data-cf-beacon='{"token": "{{ $.Site.Params.cloudflare.token }}"}'></script>
+<!-- End Cloudflare Web Analytics -->

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -137,6 +137,13 @@ models:
               - type: string
                 name: code
                 label: URL for Goat Counter
+          - type: object
+            name: cloudflare
+            label:  Cloudflare Web Analytics (optional)
+            fields:
+              - type: string
+                name: token
+                label: token for Cloudflare Web Analytics
       - type: object
         name: languages
         fields:


### PR DESCRIPTION
### Prerequisites

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Add support of Cloudflare Web Analytics.

``` toml
# If you want to use Cloudflare Web Analytics(https://cloudflare.com) for analytics, add this section
[params.cloudflare]
    token = "token"
```
