### PR TITLE
Made example contents working as expected and visible

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,7 +4,7 @@ theme = "hugo-coder"
 languageCode = "en"
 defaultContentLanguage = "en"
 paginate = 20
-pygmentsStyle = "bw"
+pygmentsStyle = "b2"
 pygmentsCodeFences = true
 pygmentsCodeFencesGuessSyntax = true
 enableEmoji = true
@@ -190,3 +190,9 @@ url = "projects/"
 name = "Contato"
 weight = 5
 url = "contact/"
+
+# Enable html support inside markdown
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true

--- a/exampleSite/content/posts/math-typesetting.md
+++ b/exampleSite/content/posts/math-typesetting.md
@@ -3,7 +3,7 @@ author: Hugo Authors
 title: Math Typesetting
 date: 2019-03-08
 description: A brief guide to setup KaTeX
-math: true
+katex: true
 ---
 
 Mathematical notation in a Hugo project can be enabled by using third party JavaScript libraries.
@@ -21,27 +21,13 @@ In this example we will be using [KaTeX](https://katex.org/)
 {{ end }}
 ```
 
-- To enable KaTex globally set the parameter `math` to `true` in a project's configuration
-- To enable KaTex on a per page basis include the parameter `math: true` in content files
+- To enable KaTex on a per page basis include the parameter `katex: true` in content files
 
 **Note:** Use the online reference of [Supported TeX Functions](https://katex.org/docs/supported.html)
 
-{{< math.inline >}}
-{{ if or .Page.Params.math .Site.Params.math }}
-<!-- KaTeX -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
-{{ end }}
-{{</ math.inline >}}
-
 ### Examples
 
-{{< math.inline >}}
-<p>
-Inline math: \(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…\)
-</p>
-{{</ math.inline >}}
+Inline math: $(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…)$
 
 Block math:
 $$

--- a/exampleSite/content/posts/math-typesetting.pt-br.md
+++ b/exampleSite/content/posts/math-typesetting.pt-br.md
@@ -3,7 +3,7 @@ author: Hugo Authors
 title: Configuração de Equações Matemáticas
 date: 2019-03-08
 description: Um guia rápido sobre utilizar KaTeX
-math: true
+katex: true
 ---
 
 Em um projeto Hugo as Notações Matemáticas podem ser usadas com a ajuda de bibliotecas JavaScript de terceiros.
@@ -21,27 +21,13 @@ Nesse exemplo usaremos o [KaTeX](https://katex.org/).
 {{ end }}
 ```
 
-- Para ativar o KaTex globalmente defina o parâmetro `math` como `true` na confgiuração do projeto
-- Para ativar o KaTex em páginas específicas inclua o parâmetro `math: true` nos arquivos de conteúdo
+- Para ativar o KaTex em páginas específicas inclua o parâmetro `katex: true` nos arquivos de conteúdo
 
 **Nota:** Use a referência online [Supported TeX Functions](https://katex.org/docs/supported.html) como base para criar notações matemáticas.
 
-{{< math.inline >}}
-{{ if or .Page.Params.math .Site.Params.math }}
-<!-- KaTeX -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
-{{ end }}
-{{</ math.inline >}}
-
 ### Examples
 
-{{< math.inline >}}
-<p>
-Notação inline: \(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…\)
-</p>
-{{</ math.inline >}}
+Notação inline: $(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…)$
 
 Notação em bloco:
 $$


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

* Change `pygmentsStyle` from _bw_ to _b2_ to make it more readable in dark
  mode
* Add ability to insert HTML inside of markdowns
* `math: true` uses mathjax. So use `katex:true` instead
* Remove not working short codes

### Issues Resolved

* Adds visibility to codes rendered using pygments in dark mode
* The  HTML codes inside of the markdowns are now rendered correctly
* Katex codes are rendered properly

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
