### PR TITLE
style: prevent text from overflowing its line box

### DIFF
--- a/assets/scss/css/normalize.css
+++ b/assets/scss/css/normalize.css
@@ -75,6 +75,7 @@
   
   a {
     background-color: transparent;
+    word-wrap: break-word;
   }
   
   /**


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

the a may be overflowing its line box
the `a` should insert line breaks within an otherwise unbreakable string to prevent text from overflowing its line box.

### Issues Resolved

#586

### Checklist

Put an `x` into the box(es) that apply:

#### General

- the a may be overflowing its line box

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- chenkai0520
