### PR TITLE
Add custom menu item param to set url function

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,7 +12,7 @@
         {{ with .Site.Menus.main}}
           {{ range sort . }}
             <li class="navigation-item">
-              <a class="navigation-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+              <a class="navigation-link" href="{{ index (apply (slice .URL) (.Params.urlFunc | default "relLangURL") ".") 0 }}">{{ .Name }}</a>
             </li>
           {{ end }}
         {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "exampleSite/public"
 command = "cd exampleSite && hugo --themesDir=../.. --baseURL $URL"
 
 [build.environment]
-HUGO_VERSION = "0.77.0"
+HUGO_VERSION = "0.79.1"
 HUGO_THEME = "repo"
 
 [context.deploy-preview]

--- a/theme.toml
+++ b/theme.toml
@@ -20,7 +20,7 @@ features = [
   "single-column",
   "syntax-highlighting"
 ]
-min_version = "0.77.0"
+min_version = "0.79.0"
 
 [author]
 name = "Luiz F. A. de Prá"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

By default, the code will behave the same and no changes in `config.yml` are required. When needed, there will be now a possibility to customize template function used to generate menu item URLs to allow to link to pages written in another language. Hugo >= 0.79.0 is required to use menu `.Params`. Example usage:
```yaml
languages:
  pl:
    menu:
      main:
      - name: Page
        url: /en/page/
        params:
          urlFunc: relURL
```

### Issues Resolved

Resolves #600 .

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
