### PR TITLE
Add comments for customSCSS file path in config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,7 +42,7 @@ maxSeeAlsoItems = 5
 enableTwemoji = false
 # Custom CSS
 customCSS = []
-# Custom SCSS
+# Custom SCSS, file path is relative to Hugo's asset folder (default: {your project root}/assets)
 customSCSS = []
 # Custom JS
 customJS = []


### PR DESCRIPTION
This commit adds a simple comment on where to put the SCSS files specified in customSCSS setting in config.toml.