### PR TITLE
Fix customJS and customCSS feature

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,3 +102,4 @@
 - [Vladislav Matus](https://github.com/matusvla)
 - [Kirill Feoktistov](https://feoktistoff.org)
 - [Michael Weiss](https://mweiss.ch)
+- [Simon Pai](https://github.com/simonpai)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -123,7 +123,13 @@
     {{ end }}
 
     {{ range .Site.Params.customJS }}
-      <script src="{{ . | relURL }}"></script>
+      {{ if $.Site.IsServer }}
+        {{ $script := resources.Get . }}
+        <script src="{{ $script.RelPermalink }}"></script>
+      {{ else }}
+        {{ $script := resources.Get . | minify | fingerprint }}
+        <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}"></script>
+      {{ end }}
     {{ end }}
 
     {{ template "_internal/google_analytics.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -61,7 +61,13 @@
     {{ end }}
 
     {{ range .Site.Params.customCSS }}
-      <link rel="stylesheet" href="{{ . | relURL }}" />
+      {{ if $.Site.IsServer }}
+        {{ $styles := resources.Get . }}
+        <link rel="stylesheet" href="{{ $styles.RelPermalink }}" media="screen">
+      {{ else }}
+        {{ $styles := resources.Get . | minify | fingerprint }}
+        <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous" media="screen" />
+      {{ end }}
     {{ end }}
 
     {{ range .Site.Params.customSCSS }}


### PR DESCRIPTION
### Prerequisites

- [x] This pull request fixes a bug.

### Description

In the current state the customJS & customCSS feature doesn't work, because an asset will only be generated to `/public` when `.RelPermalink` is used as mentioned in the [document](https://gohugo.io/hugo-pipes/introduction/#asset-publishing).

This PR fixes the issue by aligning the implementation of including JS asset with the built-in `js/coder.js`, and aligning the handling of CSS with how it handled SCSS. I have tested with Hugo `serve` and `build`.

### Checklist

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
