### PR TITLE
Remove support for MathJax

### DIFF
--- a/layouts/partials/posts/math.html
+++ b/layouts/partials/posts/math.html
@@ -1,23 +1,4 @@
-{{- if or (.Params.math) (.Site.Params.math) -}}
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  {{/* The file is already minified */}}
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-  <script>
-    MathJax = {
-      tex: {
-        inlineMath: [
-          ['$', '$'], ['\\(', '\\)']
-        ],
-        processEscapes: true,
-        processEnvironments: true
-      },
-      options: {
-        skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
-      }
-    };
-  </script>
-{{- end -}}
-{{- if or (.Params.katex) (.Site.Params.katex) -}}
+{{- if or (.Params.math) (.Site.Params.math) (.Params.katex) (.Site.Params.katex) -}}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css"
     integrity="sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc" crossorigin="anonymous">
   {{/* The loading of KaTeX is deferred to speed up page rendering */}}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request introduces breaking change.

### Description

Removes support for MathJax. `.Params.math` and `.Site.Params.math` will now use KaTeX.

### Issues Resolved

Closes #539.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
