### PR TITLE
Remove hide configs

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,7 +18,6 @@ keywords = "blog,developer,personal"
 info = ["Full Stack DevOps", "Magician"]
 avatarURL = "images/avatar.jpg"
 #gravatar = "john.doe@example.com"
-footerContent = "Enter a text here."
 dateFormat = "January 2, 2006"
 since = 2019
 # Git Commit in Footer, uncomment the line below to enable it
@@ -164,7 +163,6 @@ author = "João Ninguém"
 info = "Full Stack DevOps e Mágico"
 description = "Sítio pessoal de João Ninguém"
 keywords = "blog,desenvolvedor,pessoal"
-footerContent = "Coloque algum texto aqui."
 
 [[languages.pt-br.menu.main]]
 name = "Sobre"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,9 +20,6 @@ avatarURL = "images/avatar.jpg"
 #gravatar = "john.doe@example.com"
 footerContent = "Enter a text here."
 dateFormat = "January 2, 2006"
-hideFooter = false
-hideCredits = false
-hideCopyright = false
 since = 2019
 # Git Commit in Footer, uncomment the line below to enable it
 commit = "https://github.com/luizdepra/hugo-coder/tree/"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,5 @@
 <footer class="footer">
   <section class="container">
-    {{ with .Site.Params.footerContent | safeHTML }}
-      <p>{{ . }}</p>
-    {{ end }}
     ©
     {{ if (and .Site.Params.since (lt .Site.Params.since now.Year)) }}
       {{ .Site.Params.since }} -

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,26 +1,18 @@
-{{ if not .Site.Params.hideFooter | default false }}
-  <footer class="footer">
-    <section class="container">
-      {{ with .Site.Params.footerContent | safeHTML }}
-        <p>{{ . }}</p>
-      {{ end }}
-      {{ if not .Site.Params.hideCopyright }}
-        ©
-        {{ if (and (.Site.Params.since) (lt .Site.Params.since now.Year)) }}
-          {{ .Site.Params.since }} -
-        {{ end }}
-        {{ now.Year }}
-        {{ with .Site.Params.author }} {{ . }} {{ end }}
-      {{ end }}
-      {{ if not .Site.Params.hideCredits }}
-        {{ if not .Site.Params.hideCopyright }} · {{ end }}
-        {{ i18n "powered_by" }} <a href="https://gohugo.io/">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/">Coder</a>.
-      {{ end }}
-      {{ if .Site.Params.commit }}
-        {{ if .GitInfo }}
-          [<a href="{{ .Site.Params.commit }}/{{ .GitInfo.Hash }}">{{ .GitInfo.AbbreviatedHash }}</a>]
-        {{ end }}
-      {{ end }}
-    </section>
-  </footer>
-{{ end }}
+<footer class="footer">
+  <section class="container">
+    {{ with .Site.Params.footerContent | safeHTML }}
+      <p>{{ . }}</p>
+    {{ end }}
+    ©
+    {{ if (and .Site.Params.since (lt .Site.Params.since now.Year)) }}
+      {{ .Site.Params.since }} -
+    {{ end }}
+    {{ now.Year }}
+    {{ with .Site.Params.author }} {{ . }} {{ end }}
+    ·
+    {{ i18n "powered_by" }} <a href="https://gohugo.io/">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/">Coder</a>.
+    {{ if (and .Site.Params.commit .GitInfo) }}
+      [<a href="{{ .Site.Params.commit }}/{{ .GitInfo.Hash }}">{{ .GitInfo.AbbreviatedHash }}</a>]
+    {{ end }}
+  </section>
+</footer>

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -51,16 +51,10 @@ models:
             name: info
           - type: string
             name: avatarURL
-          - type: boolean
-            name: hideFooter
           - type: string
             name: footerContent
           - type: string
             name: dateFormat
-          - type: boolean
-            name: hideCredits
-          - type: boolean
-            name: hideCopyright
           - type: boolean
             name: hideColorSchemeToggle
           - type: number

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -52,8 +52,6 @@ models:
           - type: string
             name: avatarURL
           - type: string
-            name: footerContent
-          - type: string
             name: dateFormat
           - type: boolean
             name: hideColorSchemeToggle
@@ -255,8 +253,6 @@ models:
             name: description
           - type: string
             name: keywords
-          - type: string
-            name: footerContent
           - type: number
             name: since
       - type: object


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request introduces breaking change.

### Description

Remove `hide` configurations, which made the footer overly messy.

Also removed `.Site.Params.footerContent`, as this could similarly be done by overriding the footer. Let me know if I overshot it with this (or just cherry-pick the first commit).

### Issues Resolved

Closes #540.