### PR TITLE
Plural translation keys

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,11 +1,17 @@
-[category]
-other = "فئة"
+[categories]
+one = "فئة"
 
-[tag]
-other = "وَسم"
+[tags]
+one = "وَسم"
 
 [series]
-other = "سلسلة"
+one = "سلسلة"
+
+[authors]
+one = "الكاتب"
+
+[posts]
+other = "المنشورات"
 
 [reading_time]
 other = "تستغرق {{ .Count }} د"
@@ -22,11 +28,5 @@ other = "بإمكانك العودة إلى <a href=\"{{ . }}\">homepage</a>."
 [powered_by]
 other = "بواسطة"
 
-[author]
-other = "الكاتب"
-
 [see_also]
 other = "انظر أيضاً"
-
-[posts]
-other = "المنشورات"

--- a/i18n/bn.toml
+++ b/i18n/bn.toml
@@ -1,14 +1,14 @@
-[category]
-other = "বিভাগ"
+[categories]
+one = "বিভাগ"
 
-[tag]
-other = "ট্যাগ"
+[tags]
+one = "ট্যাগ"
 
 [series]
-other = "সিরিজ"
+one = "সিরিজ"
 
-[author]
-other = "লেখক"
+[authors]
+one = "লেখক"
 
 [posts]
 other = "সব পোস্ট"

--- a/i18n/cs.toml
+++ b/i18n/cs.toml
@@ -1,11 +1,15 @@
-[category]
-other = "kategorie"
+[categories]
+one = "kategorie"
 
-[tag]
-other = "tag"
+[tags]
+one = "tag"
 
 [series]
-other = "série"
+one = "série"
+
+[authors]
+
+[posts]
 
 [reading_time]
 other = "Délka čtení: {{ .Count }}"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,22 +1,17 @@
-[category]
-other = "Kategorie"
-
 [categories]
+one = "Kategorie"
 other = "Kategorien"
 
-[tag]
-other = "Tag"
-
 [tags]
+one = "Tag"
 other = "Tags"
 
 [series]
-other = "Serie"
-
-[author]
-other = "Autor"
+one = "Serie"
+other = "Serien"
 
 [authors]
+one = "Autor"
 other = "Autoren"
 
 [posts]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,22 +1,17 @@
-[category]
-other = "category"
-
 [categories]
+one = "category"
 other = "categories"
 
-[tag]
-other = "tag"
-
 [tags]
+one = "tag"
 other = "tags"
 
 [series]
+one = "series"
 other = "series"
 
-[author]
-other = "author"
-
 [authors]
+one = "author"
 other = "authors"
 
 [posts]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,22 +1,17 @@
-[category]
-other = "categoría"
-
 [categories]
+one = "categoría"
 other = "categorías"
 
-[tag]
-other = "etiqueta"
-
 [tags]
+one = "etiqueta"
 other = "etiquetas"
 
 [series]
-other = "serie"
-
-[author]
-other = "autor"
+one = "serie"
+other = "series"
 
 [authors]
+one = "autor"
 other = "autores"
 
 [posts]

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -1,14 +1,17 @@
-[category]
-other = "kategoria"
+[categories]
+one = "kategoria"
 
-[tag]
-other = "merkki"
+[tags]
+one = "merkki"
 
 [series]
-other = "sarja"
+one = "sarja"
 
-[author]
-other = "Kirjoittaja"
+[authors]
+one = "Kirjoittaja"
+
+[posts]
+other = "Artikkelit"
 
 [reading_time]
 one = "Yksi lukuminuutti"
@@ -28,6 +31,3 @@ other = "Tarjoaa"
 
 [see_also]
 other = "Katso myös"
-
-[posts]
-other = "Artikkelit"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,14 +1,21 @@
-[category]
-other = "catégorie"
+[categories]
+one = "catégorie"
+other = "catégories"
 
-[tag]
-other = "tag"
+[tags]
+one = "tag"
+other = "tags"
 
 [series]
+one = "série"
 other = "séries"
 
-[author]
-other = "auteur"
+[authors]
+one = "auteur"
+other = "auteurs"
+
+[posts]
+other = "articles"
 
 [reading_time]
 one = "Une minute de lecture"
@@ -28,6 +35,3 @@ other = "Propulsé par"
 
 [see_also]
 other = "Voir aussi dans"
-
-[posts]
-other = "Articles"

--- a/i18n/he.toml
+++ b/i18n/he.toml
@@ -1,14 +1,17 @@
-[category]
-other = "קטגוריה"
+[categories]
+one = "קטגוריה"
 
-[tag]
-other = "תגית"
+[tags]
+one = "תגית"
 
 [series]
-other = "סדרה"
+one = "סדרה"
 
-[author]
-other = "סופר"
+[authors]
+one = "סופר"
+
+[posts]
+other = "פוסטים"
 
 [reading_time]
 one = "דקה אחת לקרוא"
@@ -28,7 +31,3 @@ other = "מופעל על ידי"
 
 [see_also]
 other = "רואה עוד ב"
-
-[posts]
-other = "פוסטים"
-

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -1,14 +1,17 @@
-[category]
-other = "श्रेणी"
+[categories]
+one = "श्रेणी"
 
-[tag]
-other = "टैग"
+[tags]
+one = "टैग"
 
 [series]
-other = "श्रृंखला"
+one = "श्रृंखला"
 
-[author]
-other = "लेखक"
+[authors]
+one = "लेखक"
+
+[posts]
+other = "सामग्री"
 
 [reading_time]
 one = "एक पढ़ने का समय"
@@ -28,6 +31,3 @@ other = "द्वारा संचालित"
 
 [see_also]
 other = "यह भी देखें"
-
-[posts]
-other = "सामग्री"

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -1,14 +1,14 @@
-[category]
-other = "Kategória"
+[categories]
+one = "Kategória"
 
-[tag]
-other = "Címke"
+[tags]
+one = "Címke"
 
 [series]
-other = "Sorozat"
+one = "Sorozat"
 
-[author]
-other = "Szerző"
+[authors]
+one = "Szerző"
 
 [posts]
 other = "Írások"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -1,14 +1,14 @@
-[category]
-other = "kategori"
+[categories]
+one = "kategori"
 
-[tag]
-other = "label"
+[tags]
+one = "label"
 
 [series]
-other = "seri"
+one = "seri"
 
-[author]
-other = "penulis"
+[authors]
+one = "penulis"
 
 [posts]
 other = "artikel"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -1,14 +1,18 @@
-[category]
-other = "categoria"
+[categories]
+one = "categoria"
+other = "categorie"
 
-[tag]
-other = "tag"
+[tags]
+one = "tag"
+other = "tags"
 
 [series]
+one = "serie"
 other = "serie"
 
-[author]
-other = "autore"
+[authors]
+one = "autore"
+other = "autori"
 
 [posts]
 other = "post"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,14 +1,14 @@
-[category]
-other = "カテゴリー"
+[categories]
+one = "カテゴリー"
 
-[tag]
-other = "タグ"
+[tags]
+one = "タグ"
 
 [series]
-other = "シリーズ"
+one = "シリーズ"
 
-[author]
-other = "筆者"
+[authors]
+one = "筆者"
 
 [posts]
 other = "記事"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,14 +1,14 @@
-[category]
-other = "카테고리"
+[categories]
+one = "카테고리"
 
-[tag]
-other = "태그"
+[tags]
+one = "태그"
 
 [series]
-other = "시리즈"
+one = "시리즈"
 
-[author]
-other = "저자"
+[authors]
+one = "저자"
 
 [posts]
 other = "포스트"

--- a/i18n/ms.toml
+++ b/i18n/ms.toml
@@ -1,11 +1,15 @@
-[category]
-other = "kategori"
+[categories]
+one = "kategori"
 
-[tag]
-other = "teg"
+[tags]
+one = "teg"
 
 [series]
-other = "siri"
+one = "siri"
+
+[authors]
+
+[posts]
 
 [reading_time]
 one = "Bacaan 1 minit"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -1,14 +1,14 @@
-[category]
-other = "Categorie"
+[categories]
+one = "Categorie"
 
-[tag]
-other = "Label"
+[tags]
+one = "Label"
 
 [series]
-other = "Serie"
+one = "Serie"
 
-[author]
-other = "Auteur"
+[authors]
+one = "Auteur"
 
 [posts]
 other = "Berichten"

--- a/i18n/np.toml
+++ b/i18n/np.toml
@@ -1,14 +1,17 @@
-[category]
-other = "वर्ग"
+[categories]
+one = "वर्ग"
 
-[tag]
-other = "ट्याग"
+[tags]
+one = "ट्याग"
 
 [series]
-other = "श्रृंखला"
+one = "श्रृंखला"
 
-[author]
-other = "लेखक"
+[authors]
+one = "लेखक"
+
+[posts]
+other = "सामग्री"
 
 [reading_time]
 one = "एक मिनेट पढाई"
@@ -28,6 +31,3 @@ other = "द्वारा संचालित"
 
 [see_also]
 other = "यो पनि हेर्नुहोस।"
-
-[posts]
-other = "सामग्री"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -1,22 +1,17 @@
-[category]
-other = "kategoria"
-
 [categories]
+one = "kategoria"
 other = "kategorie"
 
-[tag]
-other = "tag"
-
 [tags]
+one = "tag"
 other = "tagi"
 
 [series]
+one = "seria"
 other = "seria"
 
-[author]
-other = "autor(ka)"
-
 [authors]
+one = "autor(ka)"
 other = "autorzy"
 
 [posts]

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -1,22 +1,17 @@
-[category]
-other = "categoria"
-
 [categories]
+one = "categoria"
 other = "categorias"
 
-[tag]
-other = "etiqueta"
-
 [tags]
+one = "etiqueta"
 other = "etiquetas"
 
 [series]
+one = "séries"
 other = "séries"
 
-[autor]
-other = "autor"
-
 [authors]
+one = "autor"
 other = "autores"
 
 [posts]

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -1,22 +1,17 @@
-[category]
-other = "categorie"
-
 [categories]
+one = "categorie"
 other = "categorii"
 
-[tag]
-other = "etichetă"
-
 [tags]
+one = "etichetă"
 other = "etichete"
 
 [series]
+one = "serie"
 other = "serie"
 
-[author]
-other = "autor"
-
 [authors]
+one = "autor"
 other = "autori"
 
 [posts]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -1,11 +1,17 @@
-[category]
-other = "категория"
+[categories]
+one = "категория"
 
-[tag]
-other = "тэг"
+[tags]
+one = "тэг"
 
 [series]
-other = "серии"
+one = "серии"
+
+[authors]
+one = "автор"
+
+[posts]
+other = "статьи"
 
 [reading_time]
 one = "Читать одну минуту"
@@ -23,12 +29,6 @@ other = "Можете вернуться обратно на <a href=\"{{ . }}\"
 
 [powered_by]
 other = "Работает на"
-
-[author]
-other = "автор"
-
-[posts]
-other = "статьи"
 
 [see_also]
 other = "Также смотреть"

--- a/i18n/se.toml
+++ b/i18n/se.toml
@@ -1,22 +1,17 @@
-[category]
-other = "Kategori"
-
 [categories]
+one = "Kategori"
 other = "Katgorier"
 
-[tag]
-other = "Tagg"
-
 [tags]
+one = "Tagg"
 other = "Taggar"
 
 [series]
+one = "Serie"
 other = "Serie"
 
-[author]
-other = "Författare"
-
 [authors]
+one = "Författare"
 other = "Författare"
 
 [posts]

--- a/i18n/sk.toml
+++ b/i18n/sk.toml
@@ -1,14 +1,17 @@
-[posts]
-other = "články"
+[categories]
+one = "kategória"
 
-[category]
-other = "kategória"
-
-[tag]
-other = "téma"
+[tags]
+one = "téma"
 
 [series]
-other = "diel"
+one = "diel"
+
+[authors]
+one = "autor"
+
+[posts]
+other = "články"
 
 [reading_time]
 one = "Prečítate si za minútu"
@@ -27,9 +30,6 @@ other = "Späť na <a href=\"{{ . }}\">domácu stránku</a>."
 
 [see_also]
 other = "Pozrite tiež"
-
-[author]
-other = "autor"
 
 [powered_by]
 other = "Táto stránka bola vytvorená cez"

--- a/i18n/sq.toml
+++ b/i18n/sq.toml
@@ -1,22 +1,17 @@
-[category]
-other = "kategori"
-
 [categories]
+one = "kategori"
 other = "kategoritë"
 
-[tag]
-other = "shenjim"
-
 [tags]
+one = "shenjim"
 other = "shenjuesat"
 
 [series]
+one = "seritë"
 other = "seritë"
 
-[author]
-other = "autori"
-
 [authors]
+one = "autori"
 other = "autorë"
 
 [posts]

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -1,14 +1,17 @@
-[category]
-other = "kategori"
+[categories]
+one = "kategori"
 
-[tag]
-other = "tag"
+[tags]
+one = "tag"
 
 [series]
-other = "dizi"
+one = "dizi"
 
-[author]
-other = "yazar"
+[authors]
+one = "yazar"
+
+[posts]
+other = "Gönderiler"
 
 [reading_time]
 one = "Bir dakikalık okuma"
@@ -28,6 +31,3 @@ other = "Site program altyapısı"
 
 [see_also]
 other = "Ayrıca bakınız"
-
-[posts]
-other = "Gönderiler"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -1,22 +1,17 @@
-[category]
-other = "分类"
-
 [categories]
+one = "分类"
 other = "分类"
-
-[tag]
-other = "标签"
 
 [tags]
+one = "标签"
 other = "标签"
 
 [series]
+one = "系列"
 other = "系列"
 
-[author]
-other = "作者"
-
 [authors]
+one = "作者"
 other = "作者"
 
 [posts]

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -1,14 +1,17 @@
-[category]
-other = "分類"
+[categories]
+one = "分類"
 
-[tag]
-other = "標籤"
+[tags]
+one = "標籤"
 
 [series]
-other = "系列"
+one = "系列"
 
-[author]
-other = "作者"
+[authors]
+one = "作者"
+
+[posts]
+other = "文章"
 
 [reading_time]
 one = "閱讀時間 1 分鐘"
@@ -28,6 +31,3 @@ other = "技術支援"
 
 [see_also]
 other = "參見"
-
-[posts]
-other = "文章"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,9 @@
 {{ define "title" }}
   {{- if eq .Kind "term" -}}
-    {{- i18n .Data.Singular | title -}}
+    {{- i18n .Data.Plural 1 | title -}}
     {{- print ": " -}}
   {{- end -}}
-
-  {{- .Title }} · {{ .Site.Title -}}
+  {{- i18n (lower .Title) | default .Title | title }} · {{ .Site.Title -}}
 {{ end }}
 {{ define "content" }}
   {{ partial "list.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,10 +1,9 @@
 {{ define "title" }}
   {{- if eq .Kind "term" -}}
-    {{- i18n .Data.Singular | title -}}
+    {{- i18n .Data.Plural | title -}}
     {{- print ": " -}}
   {{- end -}}
-
-  {{- .Title }} · {{ .Site.Title -}}
+  {{- i18n (lower .Title) | default .Title | title }} · {{ .Site.Title -}}
 {{ end }}
 {{ define "content" }}
   {{ partial "terms.html" . }}

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -2,10 +2,9 @@
   <h1 class="title">
     <a class="title-link" href="{{ .Permalink | safeURL }}">
       {{- if eq .Kind "term" -}}
-        {{- i18n .Data.Singular | title -}}
+        {{- i18n .Data.Plural 1 | title -}}
         {{- print ": " -}}
       {{- end -}}
-
       {{- i18n (lower .Title) | default .Title | title -}}
     </a>
   </h1>

--- a/layouts/partials/taxonomy/authors.html
+++ b/layouts/partials/taxonomy/authors.html
@@ -1,9 +1,9 @@
 <div class="authors">
-    <i class="fa fa-user" aria-hidden="true"></i>
-    {{- range $index, $el := . -}}
-      {{- if gt $index 0 }}
-        <span class="separator">•</span>
-      {{- end }}
-      <a href="{{ ( printf "authors/%s/" ( . | urlize ) ) | relLangURL }}">{{ . }}</a>
-    {{- end -}}
-  </div>
+  <i class="fa fa-user" aria-hidden="true"></i>
+  {{- range $index, $el := . -}}
+    {{- if gt $index 0 }}
+      <span class="separator">•</span>
+    {{- end }}
+    <a href="{{ ( printf "authors/%s/" ( . | urlize ) ) | relLangURL }}">{{ . }}</a>
+  {{- end -}}
+</div>

--- a/layouts/partials/terms.html
+++ b/layouts/partials/terms.html
@@ -2,10 +2,9 @@
   <h1 class="title">
     <a class="title-link" href="{{ .Permalink | safeURL }}">
       {{- if eq .Kind "term" -}}
-      {{- i18n .Data.Singular | title -}}
-      {{- print ": " -}}
+        {{- i18n .Data.Plural | title -}}
+        {{- print ": " -}}
       {{- end -}}
-
       {{- i18n (lower .Title) | default .Title | title -}}
     </a>
   </h1>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Use plural translation keys for taxonomy titles, as suggested by #608.

### Issues Resolved

Addresses #608 partially. The actual new translations are missing – most languages miss the plural translations (as mentioned in https://github.com/luizdepra/hugo-coder/issues/608#issue-1025635181). For `series` (plural) I added translations in German, French, Italian and Spanish.