### PR TITLE
Set `color-scheme` property of `:root` element

### DIFF
--- a/assets/js/coder.js
+++ b/assets/js/coder.js
@@ -33,6 +33,7 @@ function setTheme(theme) {
     let inverse = theme === 'dark' ? 'light' : 'dark';
     body.classList.remove('colorscheme-' + inverse);
     body.classList.add('colorscheme-' + theme);
+    document.documentElement.style['color-scheme'] = theme;
 }
 
 function rememberTheme(theme) {


### PR DESCRIPTION
### Prerequisites

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

By setting the `color-scheme` property of the `:root` element we get matching (dark or light) scrollbars and form controls.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme