### PR TITLE
Add jsdelivr to scriptsrc for Katex

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,3 +105,4 @@
 - [Michael Weiss](https://mweiss.ch)
 - [Simon Pai](https://github.com/simonpai)
 - [Brenton Mallen](https://github.com/brentonmallen1)
+- [Xiaoyang Luo](https://github.com/ccviolett/)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -82,7 +82,12 @@ stylesrc = [
   "https://fonts.googleapis.com/",
   "https://cdn.jsdelivr.net/"
 ]
-scriptsrc = ["'self'", "'unsafe-inline'", "https://www.google-analytics.com"]
+scriptsrc = [
+  "'self'", 
+  "'unsafe-inline'", 
+  "https://www.google-analytics.com",
+  "https://cdn.jsdelivr.net/"
+]
 prefetchsrc = ["'self'"]
 # connect-src directive – defines valid targets for to XMLHttpRequest (AJAX), WebSockets or EventSource
 connectsrc = ["'self'", "https://www.google-analytics.com"]


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This pull request add "https://cdn.jsdelivr.net/" to `scriptsrc` in the exampleSite's `config.toml`. 

When run the exampleSite, I try to use Katex but it doesn't work.

I check the Console. It shows that:

![](https://raw.githubusercontent.com/ccviolett/CCImage/main/Screenshot%20from%202022-01-17%2009-36-38.png)

So I realize maybe we should add the src of the script to `script-src` in config.toml.

The exampleSite for the new user, like me, who just what to use hugo with hugo-coder theme to write something, should be able to run with no mistake.  

Before this change, the Katex module can't use due to the `Content-Security-Policy`. I found that we put "https://cdn.jsdelivr.net/" to `stylescr` but not to `scriptsrc`. So I did it.

### Issues Resolved

None

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
