### PR TITLE
Remove obsolete meta language tag

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -107,3 +107,4 @@
 - [Brenton Mallen](https://github.com/brentonmallen1)
 - [Xiaoyang Luo](https://github.com/ccviolett/)
 - [Michiel Appelman](https://appelman.se)
+- [Mark Wood](https://digitalnotions.net)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Language" content="{{ .Site.Language.Lang }}">
     <meta name="color-scheme" content="light dark">
 
     {{ if .Site.Params.csp }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Validation of sites generated with the hugo-coder theme throw validation errors due to the language being specified in a meta tag.

`Error: Using the meta element to specify the document-wide default language is obsolete. Consider specifying the language on the root element instead.`

This error is provided by the [W3 Validator](https://validator.w3.org/nu/#textarea) and can be recreated by pasting the following html into the manual verification text entry:

```
<!DOCTYPE html>
<html lang="en">
<head>
<title>Test</title>
<meta http-equiv="Content-Language" content="en">
<meta charset="UTF-8">
</head>
<body>
<p>Test</p>
</body>
</html>
```

### Issues Resolved

This pull requests resolves the above error by removing the language meta tag. Since the hugo-coder theme already supplies the language as part of the `<html>` tag, there is no need to add anything additional to the theme to achieve compliance.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
