### PR TITLE
Add macOS mask icon + web app manifest support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -108,3 +108,4 @@
 - [Xiaoyang Luo](https://github.com/ccviolett/)
 - [Michiel Appelman](https://appelman.se)
 - [Mark Wood](https://digitalnotions.net)
+- [Sam A.](https://samsapti.dev)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -86,6 +86,9 @@
 
     <link rel="apple-touch-icon" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
+    
+    <link rel="manifest" href="{{ .Site.Params.manifest | default "/site.webmanifest" | relURL }}">
+    <link rel="mask-icon" href="{{ .Site.Params.mask_icon | default "/images/safari-pinned-tab.svg" | relURL }}" color="{{ .Site.Params.mask_icon_color | default "#5bbad5" }}">
 
     {{ range .AlternativeOutputFormats -}}
       {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This PR adds ̀`<link>` tags for web app manifest and the macOS mask
icon (used for Safari pinned tabs and the touch bar). The changes are
applied to ̀`baseof.html` and supports overrides via a set of new keys in
`config.toml`, respectively `manifest`, `mask_icon` and `mask_icon_color`.

### Issues Resolved

None.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
