### PR TITLE
Move <head> back to baseof.html

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -116,3 +116,4 @@
 - [Saurmandal](https://saur.neocities.org)
 - [Jneo8](https://github.com/jneo8)
 - [Daniel Nduati](https://github.com/DanNduati)
+- [Daniel Truemper](https://gthub.com/truemped)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}">
-{{ partial "head.html" . }}
+
+<head>
+  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+  {{ partial "head.html" . }}
+
+</head>
 
 {{ $csClass := "colorscheme-light" }}
 {{ if eq .Site.Params.colorScheme "dark" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,23 +1,19 @@
-<head>
-  {{ partial "head/meta-tags.html" . }}
+{{ partial "head/meta-tags.html" . }}
 
-  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+{{ if .Permalink }}
+<link rel="canonical" href="{{ .Permalink }}">
+{{ end }}
 
-  {{ if .Permalink }}
-  <link rel="canonical" href="{{ .Permalink }}">
-  {{ end }}
+{{ partialCached "head/theme-styles.html" . }}
 
-  {{ partialCached "head/theme-styles.html" . }}
+{{ partialCached "head/color-scheme.html" . }}
 
-  {{ partialCached "head/color-scheme.html" . }}
+{{ partialCached "head/custom-styles.html" . }}
 
-  {{ partialCached "head/custom-styles.html" . }}
+{{ partialCached "head/custom-icons.html" . }}
 
-  {{ partialCached "head/custom-icons.html" . }}
+{{ partial "head/alternative-output-formats.html" . }}
 
-  {{ partial "head/alternative-output-formats.html" . }}
+{{ partialCached "head/hugo-generator.html" . }}
 
-  {{ partialCached "head/hugo-generator.html" . }}
-
-  {{ partial "head/extensions.html" . }}
-</head>
+{{ partial "head/extensions.html" . }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This moves the hugo template block for the `title` back to the `baseof.html`.
Title in posts are rendered correctly again.

### Issues Resolved

Fixes #708.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
