### PR TITLE
Make screenreaders do the right thing with heading links.

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,6 +1,7 @@
 <h{{ .Level }} id="{{ .Anchor | safeURL }}">
   {{ .Text | safeHTML }}
   <a class="heading-link" href="#{{ .Anchor | safeURL }}">
-    <i class="fa fa-link" aria-hidden="true"></i>
+    <i class="fa fa-link" aria-hidden="true" title="{{ i18n "link_to_heading" | default "Link to heading" }}"></i>
+    <span class="sr-only">{{ i18n "link_to_heading" | default "Link to heading" }}</span>
   </a>
 </h{{ .Level }}>

--- a/layouts/partials/posts/series.html
+++ b/layouts/partials/posts/series.html
@@ -8,7 +8,8 @@
       <h3 id="{{ i18n "see_also" | default "See also in" | anchorize }}-{{ anchorize . | safeURL }}">
         {{ i18n "see_also" | default "See also in" }} {{ . }}
         <a class="heading-link" href="#{{ i18n "see_also" | default "See also in" | anchorize }}-{{ anchorize . | safeURL }}">
-          <i class="fa fa-link" aria-hidden="true"></i>
+          <i class="fa fa-link" aria-hidden="true" title="{{ i18n "link_to_heading" | default "Link to heading" }}"></i>
+          <span class="sr-only">{{ i18n "link_to_heading" | default "Link to heading" }}</span>
         </a>
       </h3>
       <nav>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Currently, hugo-coder breaks Web Content Accessibility Guidelines by having two instances of links with no readable content inside them.  They are the link icons that produce the heading links.  Because the only content inside them is aria-hidden, the screenreader has nothing to read and will either skip mentioning the presence of the link entirely or will read out the entire URL.

Thankfully, Font Awesome (and by extension Fork Awesome) have an advised solution for this.

https://fontawesome.com/docs/web/dig-deeper/accessibility#semantic-icons

See the part about 'icons that have semantic meaning'.

In this case, we add a hidden element for screenreaders to read, plus a tooltip on the element itself.  Since the element will display or be read, it is generated through i18n so that it can be internationali(s/z)ed.

Note that in the SCSS we have for Fork Awesome, it is called 'sr-only' rather than 'fa-sr-only' but it has identical results.

### Issues Resolved

#712 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
