### PR TITLE
add giscus for hugo-coder

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,3 +117,4 @@
 - [Jneo8](https://github.com/jneo8)
 - [Daniel Nduati](https://github.com/DanNduati)
 - [Simon Hollingshead](https://github.com/simonhollingshead)
+- [d0zingcat](https://github.com/d0zingcat)

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -299,6 +299,20 @@ disqusShortname = "yourdiscussshortname"
   tag = "tags"
   author = "authors"
 
+# Giscus
+# Should follow the tutorials [here](https://giscus.app/).
+[params.giscus] # https://giscus.app
+repo = "{repo}" # Repo where the comments will live
+repo_id = "{repo_id}" # Repo where the comments will live
+category = "General" # Repo where the comments will live
+category_id = "{cate_id}" # Repo where the comments will live
+mapping = "pathname" # How Utterances will match comment to page
+theme = "light" # What theme to use
+reactions_enabled = "1" # Enable reactions
+emit_metadata= "0" # Emit metadata
+lang = "en" # Language
+
+
 # Social links
 [[params.social]]
   name = "Github"

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -311,6 +311,7 @@ theme = "light" # What theme to use
 reactions_enabled = "1" # Enable reactions
 emit_metadata= "0" # Emit metadata
 lang = "en" # Language
+input_position = "bottom" # Input position
 
 
 # Social links

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -116,6 +116,7 @@ theme = "light" # What theme to use
 reactions_enabled = "1" # Enable reactions
 emit_metadata= "0" # Emit metadata
 lang = "en" # Language
+input_position = "bottom" # Input position
 
 [[params.social]]
 name = "Github"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -78,7 +78,7 @@ customJS = []
 childsrc = ["'self'"]
 fontsrc = ["'self'", "https://fonts.gstatic.com", "https://cdn.jsdelivr.net/"]
 formaction = ["'self'"]
-framesrc = ["'self'"]
+framesrc = ["'self'", "https://giscus.app/"]
 imgsrc = ["'self'"]
 objectsrc = ["'none'"]
 stylesrc = [
@@ -90,6 +90,7 @@ stylesrc = [
 scriptsrc = [
   "'self'",
   "'unsafe-inline'",
+  "https://giscus.app/",
   "https://www.google-analytics.com",
   "https://cdn.jsdelivr.net/"
 ]
@@ -102,6 +103,19 @@ category = "categories"
 series = "series"
 tag = "tags"
 author = "authors"
+
+# Giscus
+# Should follow the tutorials [here](https://giscus.app/).
+[params.giscus] # https://giscus.app
+repo = "{repo}" # Repo where the comments will live
+repo_id = "{repo_id}" # Repo where the comments will live
+category = "General" # Repo where the comments will live
+category_id = "{cate_id}" # Repo where the comments will live
+mapping = "pathname" # How Utterances will match comment to page
+theme = "light" # What theme to use
+reactions_enabled = "1" # Enable reactions
+emit_metadata= "0" # Emit metadata
+lang = "en" # Language
 
 [[params.social]]
 name = "Github"

--- a/layouts/partials/posts/giscus.html
+++ b/layouts/partials/posts/giscus.html
@@ -10,8 +10,8 @@
           data-theme="{{site.Params.giscus.theme}}"
           data-lang="{{site.Params.giscus.lang}}"
           data-emit-metadata="{{site.Params.giscus.emit_metadata}}"
+          data-input-position="{{site.Params.giscus.input_position}}"
           data-loading="lazy"
-          data-input-position="top"
           crossorigin="anonymous"
           async>
     </script>

--- a/layouts/partials/posts/giscus.html
+++ b/layouts/partials/posts/giscus.html
@@ -1,0 +1,19 @@
+<!-- giscus -->
+{{- if .Site.Params.giscus.repo }}
+    <script src="https://giscus.app/client.js"
+          data-repo="{{site.Params.giscus.repo}}"
+          data-repo-id="{{site.Params.giscus.repo_id}}"
+          data-category="{{site.Params.giscus.category}}"
+          data-category-id="{{site.Params.giscus.category_id}}"
+          data-mapping="{{site.Params.giscus.mapping}}"
+          data-reactions-enabled="{{site.Params.giscus.reactions_enabled}}"
+          data-theme="{{site.Params.giscus.theme}}"
+          data-lang="{{site.Params.giscus.lang}}"
+          data-emit-metadata="{{site.Params.giscus.emit_metadata}}"
+          data-loading="lazy"
+          data-input-position="top"
+          crossorigin="anonymous"
+          async>
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="https://github.com/giscus">comments powered by giscuss.</a></noscript>
+{{- end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -44,6 +44,7 @@
         {{ partial "posts/disqus.html" . }}
         {{ partial "posts/commento.html" . }}
         {{ partial "posts/utterances.html" . }}
+        {{ partial "posts/giscus.html" .}}
       </footer>
     </article>
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

As we know, Disqus is a centralized service which provides comment system for static web pages. But we've got a few problems, e.g. we cannot export our messages and we cannot save the comments in a quite easily way. In my opion, [Giscus](https://giscus.app)  is one well-known and advanced self-hoted static web page comments management system which is based on Github Discussions. 

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
