### PR TITLE
minor fix keywords delimit

### DIFF
--- a/layouts/partials/head/meta-tags.html
+++ b/layouts/partials/head/meta-tags.html
@@ -9,7 +9,7 @@
 {{ with .Site.Params.author }}
 <meta name="author" content="{{ . }}">{{ end }}
 <meta name="description" content="{{ .Description | default (.Summary | default .Site.Params.description ) }}">
-<meta name="keywords" content="{{ (delimit .Keywords " ,") | default .Site.Params.keywords }}">
+<meta name="keywords" content="{{ (delimit .Keywords ", ") | default .Site.Params.keywords }}">
 
 {{ template "_internal/twitter_cards.html" . }}
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
### Prerequisites

- [x] This pull request fixes a very minor bug.


### Description

Some very minor fix in head meta keywords

![Снимок экрана 2022-12-06 110356](https://user-images.githubusercontent.com/71608345/205857592-53dfd796-8abb-45ff-845b-0b32e3f9cfbc.png)

![Снимок экрана 2022-12-06 110439](https://user-images.githubusercontent.com/71608345/205857728-f34ce226-86c9-49c0-a195-6e7f69e70781.png)

### Fixed

![Снимок экрана 2022-12-06 110640](https://user-images.githubusercontent.com/71608345/205857811-7de4abc6-6c27-4f63-837e-4aa03f2e0c87.png)


