### PR TITLE
Remove reference to complete config in Quick Start

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -120,3 +120,4 @@
 - [yangyangdaji](https://github.com/yangyangdaji)
 - [xiaotianxt](https://github.com/xiaotianxt)
 - [Nour Agha](https://github.com/nourkagha)
+- [Brian Lachniet](https://github.com/blachniet)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@
 To start using `hugo-coder`:
 
 1. Add the repository into your Hugo Project repository as a submodule, `git submodule add https://github.com/luizdepra/hugo-coder.git themes/coder`.
-2. Configure your `config.toml`. You can either use the [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base, or look for a complete explanation about all configurations [here](https://github.com/luizdepra/hugo-coder/wiki/Configurations). The [`config.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/config.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
+2. Configure your `config.toml`. You can use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base. The [`config.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/config.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
 3. Build your site with `hugo serve` and see the result at `http://localhost:1313/`.
 
 If you just want to test this theme, go to [this page](https://themes.gohugo.io/theme/hugo-coder/).


### PR DESCRIPTION
The link to the complete example pointed to a Wiki page which no longer exists.

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Remove a broken link in the Quick Start documentation.

### Issues Resolved

*N/A*

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
