### PR TITLE
Add custom title / translation of tags

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -122,3 +122,4 @@
 - [Nour Agha](https://github.com/nourkagha)
 - [Brian Lachniet](https://github.com/blachniet)
 - [ShortArrow](https://github.com/ShortArrow)
+- [Martin Hellspong](https://github.com/marhel)

--- a/exampleSite/content/tags/shortcodes/_index.pt-br.md
+++ b/exampleSite/content/tags/shortcodes/_index.pt-br.md
@@ -1,0 +1,5 @@
+---
+title: "Códigos curtos"
+date: 2023-01-04T11:51:36+01:00
+draft: false
+---

--- a/layouts/partials/taxonomy/tags.html
+++ b/layouts/partials/taxonomy/tags.html
@@ -5,7 +5,7 @@
       <span class="separator">•</span>
     {{- end }}
     <span class="tag">
-      <a href="{{ ( printf "tags/%s/" ( . | urlize ) ) | relLangURL }}">{{ . }}</a>
+      <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
     </span>
   {{- end -}}
 </div>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -27,7 +27,7 @@
           </div>
           {{ with .Page.Params.Authors }}{{ partial "taxonomy/authors.html" . }}{{ end }}
           {{ with .Page.Params.Categories }}{{ partial "taxonomy/categories.html" . }}{{ end }}
-          {{ with .Page.Params.Tags }}{{ partial "taxonomy/tags.html" . }}{{ end }}
+          {{ with .GetTerms "tags" }}{{ partial "taxonomy/tags.html" . }}{{ end }}
         </div>
       </header>
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [X] This pull request fixes a bug.
- [X] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This PR edits the posts/single layout to use `.GetTerms "tags"` to fetch a richer model of the tags, and the taxonomy/tags partial to use this model, instead of just urlizing the tag name, so tags with a custom title, renders correctly on a post. This also enables translation of the tags shown on a post.

To show this in action, I've added a translation of the "shortcodes" tag in the exampleSite into PT-BR, as "Códigos curtos" (my apologies, not a native speaker, this is what Google Translate said when I gave it "short codes"). 

![image](https://user-images.githubusercontent.com/2725205/210554628-4801d78b-9fb4-40b8-a82e-ac29704d0fe4.png)

The tag still links to /pt-br/tags/shortcodes/ when viewing PT-BR content, and to /tags/shortcodes/ when viewing english content. The same technique can be used to give the shortcodes tag a custom name on the english page as well.

### Issues Resolved

I had a post with a `C#` tag, which on the post tag list linked to /tags/c/ resulting in the "404 page not found" page rendering. Based on [this post on the hugo forums](https://discourse.gohugo.io/t/slash-in-tag-name/38465) I renamed the tag to `CSharp`, and added a page for this tag, where I could give the tag a title of `C#`:

    hugo new tags/CSharp/_index.md

with the content;

    ---
    title: "C#"
    date: 2023-01-04T11:51:36+01:00
    draft: false
    ---

Now, this renders as `C#` on the tags page, linking to /tags/CSharp/ just fine. However, the tag list on the post itself now showed CSharp instead of "C#". This PR fixes that.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [X] Describe what changes are being made
- [X] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [X] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
