### PR TITLE
Get featuredImage from assets/ dir or page bundles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,3 +123,4 @@
 - [Brian Lachniet](https://github.com/blachniet)
 - [ShortArrow](https://github.com/ShortArrow)
 - [Martin Hellspong](https://github.com/marhel)
+- [Tempystral](https://github.com/tempystral)

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -33,7 +33,7 @@
 
       <div class="post-content">
         {{ if .Params.featuredImage }}
-          <img src="{{ .Params.featuredImage | relURL }}" alt="Featured image"/>
+          <img src="{{ or (.Resources.GetMatch .Params.featuredImage) (resources.Get .Params.featuredImage).RelPermalink (.Params.featuredImage | relURL) }}" alt="Featured image"/>
         {{ end }}
         {{ .Content }}
       </div>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This change allows the `featuredImage` front matter param to reference images in both the `assets/` directory as well as in a [page bundle](https://gohugo.io/content-management/page-bundles/)

### Issues Resolved

https://github.com/luizdepra/hugo-coder/issues/758

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
