### PR TITLE
Only include the generator tag on the homepage.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,6 +14,6 @@
 
 {{ partial "head/alternative-output-formats.html" . }}
 
-{{ partialCached "head/hugo-generator.html" . }}
+{{ if .IsHome }}{{ partial "head/hugo-generator.html" . }}{{ end }}
 
 {{ partial "head/extensions.html" . }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

From the context links below, Hugo only ask (or use injection to force) that the meta generator tag is added to the homepage for their own monitoring of adoption, not to every page.  This change simply makes hugo-coder follow the same convention.

https://github.com/gohugoio/hugo/issues/2850#issuecomment-269673618

https://github.com/gohugoio/hugo/blob/f1e8f010f5f5990c6e172b977e5e2d2878b9a338/publisher/publisher.go#L175

### Issues Resolved

None

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
