### PR TITLE
Be stricter about what counts as an external link.

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }} {{ if or (or (strings.HasPrefix (lower .Destination) "http://") (strings.HasPrefix (lower .Destination) "https://")) ( strings.HasPrefix .Destination "//" ) }} class="external-link" target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }} {{ if findRE "^(https?:)?//" (lower .Destination) }} class="external-link" target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" }} class="external-link" target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }} {{ if or (or (strings.HasPrefix (lower .Destination) "http://") (strings.HasPrefix (lower .Destination) "https://")) ( strings.HasPrefix .Destination "//" ) }} class="external-link" target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

The current matching of adding the external-link class has both false positives and false negatives.  This attempts to be slightly stricter about what is an external link.

Before, things like http://foo.com correctly were identified as external.  However:

* A relative link to "http-specification-2.0.pdf" would be considered external because it starts with 'http'
* HTTP://EXAMPLE.COM is considered internal because 'HTTP' != 'http'
* //example.com (i.e. a protocol-relative destination) is considered internal because it does not start with 'http'.

This resolves those matters by strictly checking for the '://' in the forcibly-lowercased version of the destination, and for URLs starting with two slashes.

### Issues Resolved


### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
