### PR TITLE
Utilize canonical URLs if specified in front matter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,8 @@
 {{ partial "head/meta-tags.html" . }}
 
-{{ if .Permalink }}
+{{ if .Params.canonicalUrl }}
+<link rel="canonical" href="{{ .Params.canonicalUrl }}">
+{{ else }}
 <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

To prevent hurting the SEO when a blog post re-posted, it's recommended to use canonical URL tags.
This PR updates the concerning metatag if `canonicalUrl` specified in front matter.


### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
