### PR TITLE
add support for extra class in menu links

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -173,6 +173,7 @@ Menu Items are optional. To use them you will need to set all the following requ
 | name           | string | Yes      | Menu Item name.                          | `"Posts"`                       |
 | weight         | int    | Yes      | Menu Item order.                         | `1`                             |
 | url            | string | Yes      | URL to redirect.                         | `"/posts/"`                     |
+| class          | string | No       | Menu Item extra class attribute.         | `"menu-item"`                   |
 | target         | string | No       | URL target attribute.                    | `"_blank"`                      |
 | rel            | string | No       | URL rel attribute.                       | `"alternate"`                   |
 | type           | string | No       | URL type attribute.                      | `"application/rss+xml"`         |

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,7 +12,7 @@
         {{ with .Site.Menus.main}}
           {{ range sort . }}
             <li class="navigation-item">
-              <a class="navigation-link" href="{{ index (apply (slice .URL) (.Params.urlFunc | default "relLangURL") ".") 0 }}">{{ .Name }}</a>
+              <a class="navigation-link {{ .Params.class }}" href="{{ index (apply (slice .URL) (.Params.urlFunc | default "relLangURL") ".") 0 }}">{{ .Name }}</a>
             </li>
           {{ end }}
         {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Adds possibility to add extra class(es) to navigation-link items in the menu.

### Issues Resolved

_n/a_

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
