### PR TITLE
Fix umami analytics script name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -135,3 +135,5 @@
 - [Kemal Akkoyun](https://github.com/kakkoyun)
 - [Igetin](https://github.com/Igetin)
 - [Kirill Che.](https://github.com/g4s8)
+- [iron3oxide](https://github.com/iron3oxide)
+  

--- a/docs/analytics/umami.md
+++ b/docs/analytics/umami.md
@@ -3,5 +3,7 @@
 ```toml
 [params.umami]
     siteID = "ABCDE"
-    serverURL = "analytics.example.com"
+    scriptURL = "analytics.REGION.umami.is/SCRIPTNAME.js" 
+    # refer to the "tracking code" tab in your umami website dashboard 
+    # to obtain the script url
 ```

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -92,6 +92,11 @@ customRemoteJS = []
 # [params.pirsch]
 # code = "ABCDE"
 
+# If you want to use Umami(https://umami.is) for analytics, add this section
+# [params.umami]
+# siteID = "ABCDE"
+# scriptURL = "analytics.REGION.umami.is/SCRIPTNAME.js" 
+
 # If you want to implement a Content-Security-Policy, add this section
 # [params.csp]
 # childsrc = ["'self'"]

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,4 +1,3 @@
 <!-- Umami Analytics START -->
-<script async defer data-website-id="{{ .Site.Params.umami.siteID }}"
-    src="{{ .Site.Params.umami.serverURL }}/script.js"></script>
+<script async defer data-website-id="{{ .Site.Params.umami.siteID }}" src="{{ .Site.Params.umami.scriptURL }}"></script>
 <!-- Umami Analytics END -->

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,4 +1,4 @@
 <!-- Umami Analytics START -->
 <script async defer data-website-id="{{ .Site.Params.umami.siteID }}"
-    src="{{ .Site.Params.umami.serverURL }}/umami.js"></script>
+    src="{{ .Site.Params.umami.serverURL }}/script.js"></script>
 <!-- Umami Analytics END -->


### PR DESCRIPTION
Apparently umami renamed their script which silently broke the feature in hugo-coder.

closes #859

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

It fixes the umami analytics feature.

### Issues Resolved

#859 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
