### PR TITLE
fix: remove 404 link

### DIFF
--- a/layouts/partials/head/custom-icons.html
+++ b/layouts/partials/head/custom-icons.html
@@ -5,5 +5,4 @@
 <link rel="apple-touch-icon" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
 
-<link rel="manifest" href="{{ .Site.Params.manifest | default "/site.webmanifest" | relURL }}">
 <link rel="mask-icon" href="{{ .Site.Params.mask_icon | default "/images/safari-pinned-tab.svg" | relURL }}" color="{{ .Site.Params.mask_icon_color | default "#5bbad5" }}">


### PR DESCRIPTION
Manifest is a 404 link in the example post.  Remove it.  Alternative is to gate if this should be present.

Fixes #730

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
