### PR TITLE
Fix deprecation warning emitted by hugo

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -249,6 +249,8 @@ defaultcontentlanguage = "en"
 
 paginate = 20
 
+[services]
+[services.disqus]
 disqusShortname = "yourdiscussshortname"
 
 [markup.highlight]

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@
 To start using `hugo-coder`:
 
 1. Add the repository into your Hugo Project repository as a submodule, `git submodule add https://github.com/luizdepra/hugo-coder.git themes/coder`.
-2. Configure your `config.toml`. You can use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base. The [`config.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/config.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
+2. Configure your `config.toml`. You can use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base. The [`hugo.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/hugo.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
 3. Build your site with `hugo serve` and see the result at `http://localhost:1313/`.
 
 If you just want to test this theme, go to [this page](https://themes.gohugo.io/themes/hugo-coder/).

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -5,8 +5,11 @@ languageCode = "en"
 defaultContentLanguage = "en"
 paginate = 6
 enableEmoji = true
+
+[services]
+[services.disqus]
 # Enable Disqus comments
-# disqusShortname = "yourdiscussshortname"
+# shortname = "yourdiscussshortname"
 
 [markup.highlight]
 noClasses = false

--- a/layouts/partials/posts/disqus.html
+++ b/layouts/partials/posts/disqus.html
@@ -1,4 +1,4 @@
-{{- if and (not (eq (.Site.DisqusShortname | default "") "")) (eq (.Params.disableComments | default false) false) -}}
+{{- if and (not (eq (.Site.Config.Services.Disqus.Shortname | default "") "")) (eq (.Params.disableComments | default false) false) -}}
 <div id="disqus_thread"></div>
 <script>
   window.disqus_config = function () {
@@ -12,7 +12,7 @@
             return;
         }
         var d = document, s = d.createElement('script'); s.async = true;
-        s.src = '//' + {{ .Site.DisqusShortname }} + '.disqus.com/embed.js';
+        s.src = '//' + {{ .Site.Config.Services.Disqus.Shortname }} + '.disqus.com/embed.js';
         s.setAttribute('data-timestamp', +new Date());
         (d.head || d.body).appendChild(s);
     })();

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "exampleSite/public"
 command = "cd exampleSite && hugo --themesDir=../.. --baseURL $URL"
 
 [build.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.124.1"
 HUGO_THEME = "repo"
 
 [context.deploy-preview]


### PR DESCRIPTION
When running example site with latest hugo version 0.124.1, a deprecation warning is shown:

```
INFO  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```

This PR fixes that warning.