### PR TITLE
Hide fediverse creator when unused, and allow a globally-set value.

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -121,6 +121,7 @@ These are all the parameters used by `hugo-coder` theme.
 | keywords                      | string | Yes      | Site keywords.                                   |                                  | `"blog,developer,personal"`                      |
 | avatarURL                     | string | No       | Photo of the author.                             |                                  | `"images/avatar.jpg"`                            |
 | gravatar                      | string | No       | Gravatar photo of the author                     |                                  | `"john.doe@example.com"`                         |
+| fediverseCreator              | string | No       | The author's fediverse handle.                   |                                  | `"@johndoe@example.com"`                         |
 | faviconSVG                    | string | No       | Custom path to a SCG favicon.                    | `"/img/favicon.svg"`             | `"/img/favicon.svg"`                             |
 | favicon_32                    | string | No       | Custom path to a 32x32 favicon.                  | `"/img/favicon-32x32.png"`       | `"/img/favicon-32x32.png"`                       |
 | favicon_16                    | string | No       | Custom path to a 16x16 favicon.                  | `"/img/favicon-16x16.png"`       | `"/img/favicon-16x16.png"`                       |

--- a/layouts/partials/head/meta-tags.html
+++ b/layouts/partials/head/meta-tags.html
@@ -10,7 +10,7 @@
 <meta name="author" content="{{ . }}">{{ end }}
 <meta name="description" content="{{ .Description | default (.Summary | default .Site.Params.description ) }}">
 <meta name="keywords" content="{{ (delimit .Keywords ", ") | default .Site.Params.keywords }}">
-<meta name="fediverse:creator" content="{{ .Params.fediverseCreator }}" />
+{{ if or .Params.fediverseCreator .Site.Params.fediverseCreator }}<meta name="fediverse:creator" content="{{ .Params.fediverseCreator | default .Site.Params.fediverseCreator }}" />{{end}}
 
 {{ template "_internal/twitter_cards.html" . }}
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

The new-ish changes to support fediverse creator tags seemed to introduce two undesirable (to me) features.

1. People who didn't use the feature got an empty meta tag added to every page with no value.
2. People who own their site and are the only author of content to it needed to add the value on every single page to get it to function.

This change allows for a default value to be set, and removes the tag if it is valueless.

### Issues Resolved

#930 

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
