### PR TITLE
Add additional tags to theme.toml.

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -11,7 +11,10 @@ tags = [
   "responsive",
   "simple",
   "clean",
-  "personal"
+  "personal",
+  "light",
+  "dark",
+  "dark mode"
 ]
 features = [
   "analytics",


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

When I was looking through the hugo themes site to attempt to give a friend a link to this theme, I went into the "dark" tag on the right hand side... and realised Coder wasn't there.  Looking closer, I noticed that coder doesn't claim to be light or dark (nor "Dark mode" which is also in the sidebar for some reason).  All three seemed entirely appropriate for this theme to claim.

Compare this to https://themes.gohugo.io/themes/hugo-papermod/ or https://themes.gohugo.io/themes/hugo-theme-hello-friend-ng/ or https://themes.gohugo.io/themes/gokarna/ - all of these have both the "light" and the "dark" tag to reflect that they're toggleable.  The tags aren't used in a mutually exclusive way.

As such, for coder's discovery, I think it should also be in both sections.

I'm not sure if changing this is all that is needed (and then it would naturally propagate) or whether additional changes are needed in an official Hugo repo too, but I wouldn't have the authority to make such changes elsewhere on your behalf anyway, so I just changed the TOML file from this repo.

### Issues Resolved

No issues filed are fixed.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
