### PR TITLE
Fix deprecation warning

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -111,7 +111,7 @@ Follow [these steps](https://gohugo.io/content-management/comments/#configure-di
 
 ## Syntax Highlight
 
-The theme uses the Goldmark syntax highlight system. GitHub light and dark are set as the default styles. To choose a different style, make sure `noClasses` is not set to false (default is true) and add to your `config.toml`:
+The theme uses the Goldmark syntax highlight system. GitHub light and dark are set as the default styles. To choose a different style, make sure `noClasses` is not set to false (default is true) and add to your `hugo.toml`:
 
 ```
 [markup.highlight]
@@ -146,7 +146,7 @@ These are all the parameters used by `hugo-coder` theme.
 | commit                        | string | No       | Show the last git commit in the footer           |                                  | `"https://github.com/luizdepra/hugo-coder/tree/"`|
 | rtl                           | bool   | No       | Enable the Right To Left mode.                   | `false`                          | `true` or `false`                                |
 | math                          | bool   | No       | Enable MathJax Module and add JS into your site. | `false`                          | `true` or `false`                                |
-| katex                         | bool   | No       | Enable katex for all content types.              | `false`                          | `true` or `false`                                |
+| katex                         | bool   | No       | Enable KaTeX for all content types.              | `false`                          | `true` or `false`                                |
 | colorScheme                   | string | No       | Specify light/dark colorscheme                   | `"auto"`                         | `"auto"` or `"light"` or `"dark"`                |
 | hideColorSchemeToggle         | bool   | No       | If true, hides the color scheme toggle            | `false`                          | `true` or `false`                                |
 | customCSS                     | list   | No       | Add extra CSS files to the website.              | []                               | `["css/extra-style.css"]`                        |
@@ -270,11 +270,13 @@ theme = "hugo-coder"
 languagecode = "en"
 defaultcontentlanguage = "en"
 
-paginate = 20
+
+[pagination]
+pagerSize = 20
 
 [services]
 [services.disqus]
-disqusShortname = "yourdiscussshortname"
+shortname = "yourdiscussshortname"
 
 [markup.highlight]
 style = "github-dark"
@@ -357,8 +359,8 @@ These are the front matter variables used by `hugo-coder` theme.
 | externalLink     | string | No       | Link to an external post.                          |         | `"https://github.com/luizdepra/hugo-coder/wiki"`                                |
 | featuredImage    | string | No       | Link/path to add an image below post metadata.     |         | `"https://github.com/luizdepra/hugo-coder/blob/master/images/screenshot.png"`   |
 | math             | bool   | No       | If true, MathJax is enabled only for this post.    | `false` | `true` or `false`                                                               |
-| katex            | bool   | No       | If true, katex is enabled only for this post.      | `false` | `true` or `false`                                                               |
+| katex            | bool   | No       | If true, KaTeX is enabled only for this post.      | `false` | `true` or `false`                                                               |
 | disableComments  | bool   | No       | If true, comments are disabled.                    | `false` | `true` or `false`                                                               |
 | canonicalUrl     | string | No       | Link to override <link rel="canonical"/> in <head> | `false` | `"https://my-company.com/blog/my-blog-post-that-I-repost-without-hurtiong-seo"` |
 
-> "tags", "categories", "series" and "authors" are taxonomies defined in the `config.toml` file.
+> "tags", "categories", "series" and "authors" are taxonomies defined in the `hugo.toml` file.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@
 To start using `hugo-coder`:
 
 1. Add the repository into your Hugo Project repository as a submodule, `git submodule add https://github.com/luizdepra/hugo-coder.git themes/coder`.
-2. Configure your `config.toml`. You can use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base. The [`hugo.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/hugo.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
+2. Configure your `hugo.toml`. You can use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base. The [`hugo.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/hugo.toml) inside the [exampleSite](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) from the `exampleSite` is also a good reference.
 3. Build your site with `hugo serve` and see the result at `http://localhost:1313/`.
 
 If you just want to test this theme, go to [this page](https://themes.gohugo.io/themes/hugo-coder/).

--- a/exampleSite/content/posts/html-and-css-only-tabs.md
+++ b/exampleSite/content/posts/html-and-css-only-tabs.md
@@ -46,7 +46,7 @@ Goodbye Everybody!
 {{< /tab >}}
 {{< /tabgroup >}}
 
-## Right alighment
+## Right alignment
 
 You can also align the tabs to the right:
 

--- a/exampleSite/content/posts/math-typesetting.md
+++ b/exampleSite/content/posts/math-typesetting.md
@@ -33,8 +33,8 @@ In this example we will be using [KaTeX](https://katex.org/)
 {{ end }}
 ```
 
--   To enable KaTex globally set the parameter `math` to `true` in a project's configuration
--   To enable KaTex on a per page basis include the parameter `math: true` in content files
+-   To enable KaTeX globally set the parameter `math` to `true` in a project's configuration
+-   To enable KaTeX on a per page basis include the parameter `math: true` in content files
 
 **Note:** Use the online reference of [Supported TeX Functions](https://katex.org/docs/supported.html)
 

--- a/exampleSite/content/posts/math-typesetting.pt-br.md
+++ b/exampleSite/content/posts/math-typesetting.pt-br.md
@@ -33,8 +33,8 @@ Nesse exemplo usaremos o [KaTeX](https://katex.org/).
 {{ end }}
 ```
 
--   Para ativar o KaTex globalmente defina o parâmetro `math` como `true` na confgiuração do projeto
--   Para ativar o KaTex em páginas específicas inclua o parâmetro `math: true` nos arquivos de conteúdo
+-   Para ativar o KaTeX globalmente defina o parâmetro `math` como `true` na confgiuração do projeto
+-   Para ativar o KaTeX em páginas específicas inclua o parâmetro `math: true` nos arquivos de conteúdo
 
 **Nota:** Use a referência online [Supported TeX Functions](https://katex.org/docs/supported.html) como base para criar notações matemáticas.
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -3,8 +3,10 @@ title = "johndoe"
 theme = "hugo-coder"
 languageCode = "en"
 defaultContentLanguage = "en"
-paginate = 6
 enableEmoji = true
+
+[pagination]
+pagerSize = 6
 
 [services]
 [services.disqus]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "exampleSite/public"
 command = "cd exampleSite && hugo --themesDir=../.. --baseURL $URL"
 
 [build.environment]
-HUGO_VERSION = "0.126.1"
+HUGO_VERSION = "0.136.5"
 HUGO_THEME = "repo"
 
 [context.deploy-preview]


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [X] This pull request fixes a warning.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

When running example site with latest hugo version 0.135.5, a warning appears:

```
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0
and will be removed in a future release. Use pagination.pagerSize instead.
```

This PR solves that issues, both in code an in the documentation.
This PR also corrects and improves minor other topics in the documentation.