### PR TITLE
Example site: fix warning with latest hugo version

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -13,8 +13,12 @@ pagerSize = 6
 # Enable Disqus comments
 # shortname = "yourdiscussshortname"
 
+[markup]
 [markup.highlight]
 noClasses = false
+[markup.goldmark]
+[markup.goldmark.renderer]
+unsafe = true
 
 [params]
 author = "John Doe"


### PR DESCRIPTION
When running example site with latest hugo version `0.140.0`, a warning is shown:

```
WARN  Raw HTML omitted while rendering "/home/andreas/hugo-coder/exampleSite/content/posts/emoji-support.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
```

This PR fixes this issue.
