### PR TITLE
Hide the date if `showthedate` is false

### DIFF
--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -14,7 +14,7 @@
   <ul>
     {{ range .Paginator.Pages }}
     <li>
-      {{ if .Params.showthedate }}
+      {{ if not (.Site.Params.hidedates) }}
       <span class="date">{{ .Date | time.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</span>
       {{ end }}
       <a class="title" href="{{ .Params.externalLink | default .RelPermalink }}">{{ .Title }}</a>

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -14,7 +14,9 @@
   <ul>
     {{ range .Paginator.Pages }}
     <li>
+      {{ if .Params.showthedate }}
       <span class="date">{{ .Date | time.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</span>
+      {{ end }}
       <a class="title" href="{{ .Params.externalLink | default .RelPermalink }}">{{ .Title }}</a>
     </li>
     {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [X] This pull request introduces breaking change.

### Description

This PR hides the date in the list of blog entries depending on the `.Params.showthedate` settings.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
