### PR TITLE
Remove trailing space from headline.

### DIFF
--- a/layouts/partials/home/author.html
+++ b/layouts/partials/home/author.html
@@ -2,5 +2,5 @@
 {{ if reflect.IsSlice .Site.Params.info }}
 <h2>{{ range .Site.Params.info }}{{ . | markdownify }}<br>{{ end}}</h2>
 {{ else }}
-<h2>{{ .Site.Params.info | markdownify }} </h2>
+<h2>{{ .Site.Params.info | markdownify }}</h2>
 {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Just a minor cosmetic fix: the headline on the home page contained a trailing space, which is now gone.
Thanks for building this wonderful theme!

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
