### PR TITLE
Support adding content after "about" section

### DIFF
--- a/layouts/_partials/home.html
+++ b/layouts/_partials/home.html
@@ -9,3 +9,5 @@
 
   {{ partialCached "home/extensions.html" . }}
 </section>
+
+{{ partialCached "home/sections.html" . }}

--- a/layouts/_partials/home/extensions.html
+++ b/layouts/_partials/home/extensions.html
@@ -1,4 +1,4 @@
 {{/*
-You can add further theme extensions or customizations here if they should
-appear in after the "about" section.
+  You can add further theme extensions or customizations here if they should
+  appear in the "about" section.
 */}}

--- a/layouts/_partials/home/sections.html
+++ b/layouts/_partials/home/sections.html
@@ -1,0 +1,4 @@
+{{/*
+  You can add further sections here if they should
+  appear after the "about" section.
+*/}}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This makes a small change to provide a modular extension point for the `home` template, letting you add additional sections after the `about` section. This enables further theme customization on the homepage.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

Adds the 

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already