### PR TITLE
Support multilingual author info

### DIFF
--- a/layouts/_partials/home/author.html
+++ b/layouts/_partials/home/author.html
@@ -1,6 +1,7 @@
 <h1>{{ .Site.Params.author }}</h1>
-{{ if reflect.IsSlice .Site.Params.info }}
-<h2>{{ range .Site.Params.info }}{{ . | markdownify }}<br>{{ end}}</h2>
+{{ $info := (index .Site.Params .Lang).info | default .Site.Params.info }}
+{{ if reflect.IsSlice $info }}
+<h2>{{ range $info }}{{ . | markdownify }}<br>{{ end}}</h2>
 {{ else }}
-<h2>{{ .Site.Params.info | markdownify }}</h2>
+<h2>{{ $info | markdownify }}</h2>
 {{ end }}


### PR DESCRIPTION
### Prerequisites

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

 - Changes being made: Allow the user to customize the language of their author info under params.lang in config.toml.
 - Why: This is currently a limitation in a multilingual site.
 - How: Checking for language specific parameter and using it if available, falling back to default otherwise.

Example usage (in config.toml):
```
[params]
info = "Software Engineer"

[params.fr]
info = "Ingénieur Logiciel"
```

Disclaimer: I'm not a Go programmer so I did get help from Claude but I made sure I understood, reviewed and tested the code before offering a PR.

### Issues Resolved

Didn't see an open issue for this.

### Checklist

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
