### PR TITLE
fix: Use `x` instead of `tweet` in exampleSite

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -150,3 +150,4 @@
 -   [Gregor Podjed](https://github.com/gragorther)
 -   [dantezhu](https://github.com/dantezhu)
 -   [Alexander Lazarević](https://e11bits.com)
+-   [William Floyd](https://w-floyd.com)

--- a/exampleSite/content/posts/rich-content.md
+++ b/exampleSite/content/posts/rich-content.md
@@ -31,7 +31,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Shortcode
 
-{{< tweet user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 

--- a/exampleSite/content/posts/rich-content.pt-br.md
+++ b/exampleSite/content/posts/rich-content.pt-br.md
@@ -31,7 +31,7 @@ O Hugo vem com vários [Shortcodes Internos](https://gohugo.io/content-managemen
 
 ## Shortcode do Twitter
 
-{{< tweet user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Changes exampleSite to use `x` instead of `tweet`

### Issues Resolved

Newer versions of Hugo complain upon seeing `tweet`:
```
ERROR The "twitter", "tweet", and "twitter_simple" shortcodes were deprecated in v0.142.0 and removed in v0.156.0. Please use the "x" shortcode instead.
```

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
