### PR TITLE
Provide image attributes width and height for Gravatar

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -150,3 +150,4 @@
 -   [Gregor Podjed](https://github.com/gragorther)
 -   [dantezhu](https://github.com/dantezhu)
 -   [Alexander Lazarević](https://e11bits.com)
+-   [Oliver B. Fischer](https://stdout.oliverfischer.dev) 

--- a/layouts/_partials/home/avatar.html
+++ b/layouts/_partials/home/avatar.html
@@ -4,5 +4,5 @@
   {{ end }}
 {{ end }}
 {{ with .Site.Params.gravatar }}
-  <div class="avatar"><img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" alt="gravatar"></div>
+  <div class="avatar"><img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" width="240" height="240" alt="gravatar"></div>
 {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

The img tag for an avatar via Gravatar now specifies the width and height of the image.

Providing these attributes helps to avoid Cumulative Layout Shift. Avoiding this improves the page speed ranking of the page.

### Issues Resolved

There is no corresponding issue.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [x] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [x] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [X] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
