### PR TITLE
Fix missing external-link icon on section index (list) pages

### DIFF
--- a/layouts/_partials/list.html
+++ b/layouts/_partials/list.html
@@ -10,7 +10,9 @@
       </a>
     </h1>
   </header>
-  {{ .Content }}
+  <article>
+    {{ .Content }}
+  </article>
   <ul>
     {{ range .Paginator.Pages }}
     <li>


### PR DESCRIPTION
Fixes #1001

## What

Wraps `.Content` in `<article>` inside `layouts/_partials/list.html`, matching the existing structure of `layouts/_partials/page.html`.

## Why

The external-link icon CSS in `assets/scss/_content.scss:28` is scoped to an `article` ancestor:

```scss
article {
  a:where(.external-link):not(:has(img)):after {
    // Font Awesome external-link glyph
  }
}
```

`page.html` already wraps `.Content` in `<article>`, so single posts and pages show the icon. `list.html` did not, so any section index (`_index.md`) with external links in its body rendered the correct `external-link` class on anchors but had no `<article>` ancestor — the CSS selector never matched and no icon appeared.

## Before / after (DOM excerpt)

**Before** — no icon on `/about/`:
```html
<section class="container list">
  <header>...</header>
  <!-- .Content rendered here, outside any <article> -->
  <a href="https://dotnet.microsoft.com" class="external-link" ...>.NET</a>
  <!-- ::after never fires -->
</section>
```

**After** — icon renders:
```html
<section class="container list">
  <header>...</header>
  <article>
    <a href="https://dotnet.microsoft.com" class="external-link" ...>.NET</a>
    <!-- ::after fires, glyph appears -->
  </article>
</section>
```

## Scope

Only `layouts/_partials/list.html` is changed. The paginator `<ul>` remains outside `<article>` — it is navigation, not article content, and its items do not use `.external-link`.