### PR TITLE
fix: use the "x" shortcode instead of deprecated "tweet"

### DIFF
--- a/exampleSite/content/posts/rich-content.md
+++ b/exampleSite/content/posts/rich-content.md
@@ -29,9 +29,9 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Shortcode
+## Twitter / X Shortcode
 
-{{< tweet user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 

--- a/exampleSite/content/posts/rich-content.pt-br.md
+++ b/exampleSite/content/posts/rich-content.pt-br.md
@@ -29,9 +29,9 @@ O Hugo vem com vários [Shortcodes Internos](https://gohugo.io/content-managemen
 
 ---
 
-## Shortcode do Twitter
+## Shortcode do Twitter / X
 
-{{< tweet user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 


### PR DESCRIPTION
following the quick start document at
https://github.com/svetlemodry/hugo-coder/blob/main/docs/quick-start.md ends with the below after running the `make demo` command with the current hugo v0.161.1

ERROR The "twitter", "tweet", and "twitter_simple" shortcodes were deprecated in v0.142.0 and removed in v0.156.0. Please use the "x" shortcode instead. Built in 192 ms
ERROR error building site: logged 1 error(s)

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

Describe what this pull request achieves.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
