### PR TITLE
fix: replace deprecated .Language.LanguageName with .Language.Label

### DIFF
--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -30,7 +30,7 @@
                 {{ $node.Scratch.Set "separator" false }}
               {{ end }}
               <li class="navigation-item">
-                <a href="{{ .RelPermalink }}">{{ .Language.LanguageName | emojify }}</a>
+                <a href="{{ .RelPermalink }}">{{ .Language.Label | emojify }}</a>
               </li>
             {{ end }}
           {{ end }}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

This PR updates the language selector in the header template to use the non-deprecated Hugo field.
It replaces .Language.LanguageName with .Language.Label to remove the Hugo deprecation warning.
No functional behavior changes are expected.

### Issues Resolved

N/A (no linked issue).

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
