### PR TITLE
Add minimal alias layout page with OpenGraph data

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -154,3 +154,4 @@
 -   [Ábel Nagy](https://github.com/abel-nagy)
 -   [William Floyd](https://w-floyd.com)
 -   [Tiago Carrondo](https://carrondo.pt)
+-   [Rye](https://itsrye.dev)

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -145,6 +145,14 @@ series = "series"
 tag = "tags"
 author = "authors"
 
+[params.aliases]
+# Include OpenGraph and Twitter Card metadata in generated alias
+# redirect pages. This can improve link previews when alias URLs
+# are shared directly.
+#
+# Default: false
+socialMetadata = true
+
 [[params.social]]
 name = "Github"
 icon = "fa-brands fa-github fa-2x"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -27,6 +27,9 @@ other = "Seite nicht gefunden"
 [page_does_not_exist]
 other = "Tut mir leid, die Seite existiert leider nicht."
 
+[alias]
+other = "Weiterleiten zu:"
+
 [head_back]
 other = "Du kannst hier zurück zur <a href=\"{{ . }}\">Startseite</a>."
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -27,6 +27,9 @@ other = "Page Not Found"
 [page_does_not_exist]
 other = "Sorry, this page does not exist."
 
+[alias]
+other = "Redirecting to:"
+
 [head_back]
 other = "You can head back to the <a href=\"{{ . }}\">homepage</a>."
 

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -20,7 +20,7 @@
                 {{ else }}
                     <meta property="og:title" content="Redirecting to {{ .Permalink }}">
                 {{ end }}
-                <meta property="og:type" content="article">
+                <meta property="og:type" content="website">
             {{ end }}
         {{ end }}
     </head>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <meta charset="utf-8" />
+        <title>Redirecting to {{ .Permalink }}</title>
+        <link rel="canonical" href="{{ .Permalink }}" />
+        <meta name="robots" content="noindex,follow">
+        <meta http-equiv="refresh" content="0; url={{ .Permalink }}" />
+        {{ if site.Params.aliases.socialMetadata }}
+            {{ with .Page }}
+                <!-- alternative would be {{ template "_internal/opengraph.html" . }} and  {{ template "_internal/twitter_cards.html" . }} -->
+                <meta property="og:url" content="{{ .Permalink }}">
+                <meta property="og:site_name" content="{{ site.Title }}">
+                {{ with or .Params.description .Description .Summary }}
+                    <meta property="og:description" content="{{ . }}">
+                {{ end }}
+                {{ with .Title }}
+                    <meta property="og:title" content="{{ . }}">
+                {{ else }}
+                    <meta property="og:title" content="Redirecting to {{ .Permalink }}">
+                {{ end }}
+                <meta property="og:type" content="article">
+            {{ end }}
+        {{ end }}
+    </head>
+    <body>
+        <p>{{ i18n "alias" }} <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
+    </body>
+</html>


### PR DESCRIPTION
a minimal alias layout page for aliases including some basic opengraph data, for people sharing alias urls

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

### Description

#### Motivation

Alias URLs can be useful as stable references that remain unchanged even when content is reorganized or moved between sections of a site.
In my case, blog and developer content generate permalinks independently, which makes it difficult to move content between those sections while preserving a stable URL.
Additionally, when sharing alias URLs on social media, link previews were missing because alias pages did not expose any Open Graph metadata (bc aliases are by default html *redirects*, and leave link preview crawlers often behind while a human clicking would still get where they would expect to go by the preview).
This PR adds support for a dedicated alias page layout and optional Open Graph metadata to improve the sharing experience for alias URLs.

Note: The page is minimal and without styling as a user should ideally never get stuck at that page. And it doesn't use the internal opengraph templates, bc they are *a bit verbose* and you'd want that page to load as quickly as possible (so users won't notice the redirect as much) and only have that opengraph data to show a better experience then a bare url would be, anyhow switching to the internal templates would be possible if wanted.

#### Changes

I added a simple, minimal alias layout, which has the optional ability to have opengraph data (controlled via the params.aliases config option, unsure actually if thats clean that way, if not lmk).

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

-  [x] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
